### PR TITLE
Adjust PermissionGate render logic

### DIFF
--- a/src/components/PermissionGate.jsx
+++ b/src/components/PermissionGate.jsx
@@ -4,7 +4,14 @@ import { usePermission } from '../hooks/usePermission';
 export default function PermissionGate({ perm, children, fallback = null }) {
   const { allowed, loading, error } = usePermission(perm);
 
-  if (loading) return null;         // of een skeleton/loader
-  if (error)   return fallback;     // verberg bij fout, UI blijft rustig
-  return allowed ? children : fallback;
+  if (loading) {
+    return fallback ?? null;
+  }
+
+  if (error) {
+    console.warn('[PermissionGate]', perm, error);
+    return fallback ?? null;
+  }
+
+  return allowed ? children : (fallback ?? null);
 }


### PR DESCRIPTION
## Summary
- return fallback (or null) while permissions are loading or erroring
- log permission errors and reuse fallback rendering logic
- keep fallback as default rendering when permission not allowed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c467f91083328afab20533561d00