### PR TITLE
Add Supabase RLS patchset and permission test tooling

### DIFF
--- a/.codex/patches/20240710_supabase.patch
+++ b/.codex/patches/20240710_supabase.patch
@@ -1,0 +1,208 @@
+diff --git a/supabase/migrations/202407101200_rls_and_rpcs.sql b/supabase/migrations/202407101200_rls_and_rpcs.sql
+new file mode 100644
+index 0000000..1111111
+--- /dev/null
++++ b/supabase/migrations/202407101200_rls_and_rpcs.sql
+@@ -0,0 +1,171 @@
++-- Enable row level security on core tables
++alter table public.memberships enable row level security;
++alter table public.organizations enable row level security;
++alter table public.chats enable row level security;
++
++-- memberships policies
++create policy "Members can view their memberships"
++on public.memberships
++for select
++using (member_id = auth.uid());
++
++-- organizations policies
++create policy "Members can view their organizations"
++on public.organizations
++for select
++using (
++  exists (
++    select 1
++    from public.memberships m
++    where m.org_id = organizations.id
++      and m.member_id = auth.uid()
++  )
++);
++
++-- chats policies
++create policy "Organization members can read chats"
++on public.chats
++for select
++using (
++  org_id in (
++    select org_id
++    from public.memberships
++    where member_id = auth.uid()
++  )
++);
++
++create policy "Members can insert their own chats"
++on public.chats
++for insert
++with check (
++  owner_id = auth.uid()
++  and org_id in (
++    select org_id
++    from public.memberships
++    where member_id = auth.uid()
++  )
++);
++
++create policy "Owners and admins can update chats"
++on public.chats
++for update
++using (
++  owner_id = auth.uid()
++  or exists (
++    select 1
++    from public.memberships m
++    where m.org_id = chats.org_id
++      and m.member_id = auth.uid()
++      and m.role = 'admin'
++  )
++)
++with check (
++  owner_id = auth.uid()
++  or exists (
++    select 1
++    from public.memberships m
++    where m.org_id = chats.org_id
++      and m.member_id = auth.uid()
++      and m.role = 'admin'
++  )
++);
++
++create policy "Owners and admins can delete chats"
++on public.chats
++for delete
++using (
++  owner_id = auth.uid()
++  or exists (
++    select 1
++    from public.memberships m
++    where m.org_id = chats.org_id
++      and m.member_id = auth.uid()
++      and m.role = 'admin'
++  )
++);
++
++-- RPC definitions with p_* parameters
++create or replace function public.get_org_members(p_org uuid)
++returns setof public.memberships
++language sql
++security definer
++set search_path = public
++as $$
++  select m.*
++  from public.memberships m
++  where m.org_id = p_org;
++$$;
++
++create or replace function public.update_member_role(p_org uuid, p_target uuid, p_role text)
++returns void
++language plpgsql
++security definer
++set search_path = public
++as $$
++begin
++  update public.memberships
++  set role = p_role
++  where org_id = p_org
++    and member_id = p_target;
++end;
++$$;
++
++create or replace function public.delete_member(p_org uuid, p_target uuid)
++returns void
++language plpgsql
++security definer
++set search_path = public
++as $$
++begin
++  delete from public.memberships
++  where org_id = p_org
++    and member_id = p_target;
++end;
++$$;
++
++create or replace function public.create_invite(p_org uuid, p_email text, p_role text)
++returns uuid
++language plpgsql
++security definer
++set search_path = public
++as $$
++declare
++  v_id uuid := gen_random_uuid();
++begin
++  insert into public.invites (id, org_id, email, role, created_at)
++  values (v_id, p_org, p_email, p_role, now());
++  return v_id;
++end;
++$$;
++
++create or replace function public.accept_invite(p_token uuid)
++returns void
++language plpgsql
++security definer
++set search_path = public
++as $$
++declare
++  v_inv public.invites;
++begin
++  select *
++  into v_inv
++  from public.invites
++  where id = p_token;
++
++  if not found then
++    raise exception 'invalid invite';
++  end if;
++
++  insert into public.memberships (org_id, member_id, role, created_at)
++  values (v_inv.org_id, auth.uid(), v_inv.role, now())
++  on conflict do nothing;
++
++  delete from public.invites
++  where id = p_token;
++end;
++$$;
++
++-- Restrict RPC access
++revoke all on function public.get_org_members(uuid) from anon;
++grant execute on function public.get_org_members(uuid) to authenticated;
++grant execute on function public.update_member_role(uuid, uuid, text) to authenticated;
++grant execute on function public.delete_member(uuid, uuid) to authenticated;
++grant execute on function public.create_invite(uuid, text, text) to authenticated;
++grant execute on function public.accept_invite(uuid) to authenticated;
++
++-- Refresh PostgREST schema cache
++notify pgrst, 'reload schema';
+
+diff --git a/supabase/seed/roles.sql b/supabase/seed/roles.sql
+new file mode 100644
+index 0000000..2222222
+--- /dev/null
++++ b/supabase/seed/roles.sql
+@@ -0,0 +1,17 @@
++insert into auth.users(id, email)
++values
++('00000000-0000-0000-0000-0000000000aa', 'admin@example.com'),
++('00000000-0000-0000-0000-0000000000bb', 'agent@example.com'),
++('00000000-0000-0000-0000-0000000000cc', 'customer@example.com')
++on conflict do nothing;
++
++insert into public.organizations(id, name) values
++('10000000-0000-0000-0000-000000000000', 'Acme')
++on conflict do nothing;
++
++insert into public.memberships(org_id, member_id, role)
++values
++('10000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-0000000000aa', 'admin'),
++('10000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-0000000000bb', 'agent'),
++('10000000-0000-0000-0000-000000000000', '00000000-0000-0000-0000-0000000000cc', 'customer')
++on conflict do nothing;
+

--- a/README_PERMS.md
+++ b/README_PERMS.md
@@ -1,0 +1,25 @@
+# Permission Test Guide
+
+Deze repository bevat een permissietestscript om de nieuwe RLS-policies en RPC's te valideren.
+
+## Stappenplan
+
+1. Start de lokale stack:
+   ```bash
+   supabase start
+   ```
+2. Reset de database met de nieuwste migraties en seeds:
+   ```bash
+   supabase db reset
+   ```
+3. (Optioneel) Controleer de database via `psql` of `supabase db connect`.
+4. Voer de permissietests uit:
+   ```bash
+   node scripts/test-perms.mjs
+   ```
+
+Alle testcases zouden als `PASS` moeten loggen en het script sluit af met `All permission tests passed`.
+
+## Seeds voor lokale ontwikkeling
+
+De seed `supabase/seed/roles.sql` maakt drie testgebruikers met rollen aan. Hosted Supabase-projecten laten geen directe inserts in `auth.users` toe; deze seeds zijn bedoeld voor een lokale ontwikkelomgeving die via `supabase start` draait.

--- a/scripts/apply-patches.mjs
+++ b/scripts/apply-patches.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import { readdirSync, statSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+import process from 'node:process'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const patchesDir = join(__dirname, '..', '.codex', 'patches')
+
+let patchFiles = []
+
+try {
+  patchFiles = readdirSync(patchesDir)
+    .map((name) => ({ name, path: join(patchesDir, name) }))
+    .filter((entry) => entry.name.endsWith('.patch') && statSync(entry.path).isFile())
+    .sort((a, b) => a.name.localeCompare(b.name))
+} catch (error) {
+  console.error(`Unable to read patches directory: ${error.message}`)
+  process.exit(1)
+}
+
+if (patchFiles.length === 0) {
+  console.log(`No patch files found in ${patchesDir}`)
+  process.exit(0)
+}
+
+const shouldApply = process.argv.includes('--apply')
+
+for (const patch of patchFiles) {
+  console.log(`${shouldApply ? 'Applying' : 'Checking'} ${patch.name}...`)
+  const args = ['apply']
+  if (!shouldApply) {
+    args.push('--check')
+  }
+  args.push(patch.path)
+
+  const result = spawnSync('git', args, { stdio: 'inherit' })
+
+  if (result.status !== 0) {
+    const mode = shouldApply ? 'apply' : 'check'
+    console.error(`git ${mode} failed for ${patch.name}`)
+    process.exit(result.status ?? 1)
+  }
+}
+
+if (shouldApply) {
+  console.log('All patches applied successfully.')
+} else {
+  console.log('Dry-run complete. Re-run with --apply to write changes.')
+}

--- a/scripts/test-perms.mjs
+++ b/scripts/test-perms.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+import process from 'node:process'
+import { createClient } from '@supabase/supabase-js'
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? 'http://127.0.0.1:54321'
+const SERVICE_KEY =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_KEY
+const ANON_KEY =
+  process.env.SUPABASE_ANON_KEY ?? process.env.SUPABASE_PUBLIC_ANON_KEY
+
+if (!SERVICE_KEY) {
+  console.error('Missing SUPABASE_SERVICE_ROLE_KEY in environment')
+  process.exit(1)
+}
+
+if (!ANON_KEY) {
+  console.error('Missing SUPABASE_ANON_KEY in environment')
+  process.exit(1)
+}
+
+const ORG_ID = '10000000-0000-0000-0000-000000000000'
+const USERS = {
+  admin: {
+    id: '00000000-0000-0000-0000-0000000000aa',
+    email: 'admin@example.com',
+  },
+  agent: {
+    id: '00000000-0000-0000-0000-0000000000bb',
+    email: 'agent@example.com',
+  },
+  customer: {
+    id: '00000000-0000-0000-0000-0000000000cc',
+    email: 'customer@example.com',
+  },
+}
+
+const BASE_ORG = { id: ORG_ID, name: 'Acme' }
+const BASE_MEMBERSHIPS = [
+  { org_id: ORG_ID, member_id: USERS.admin.id, role: 'admin' },
+  { org_id: ORG_ID, member_id: USERS.agent.id, role: 'agent' },
+  { org_id: ORG_ID, member_id: USERS.customer.id, role: 'customer' },
+]
+
+const serviceClient = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+})
+
+const anonAuthClient = createClient(SUPABASE_URL, ANON_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+})
+
+const tokenCache = new Map()
+const clientCache = new Map()
+
+async function ensureBaselineData() {
+  const { error: orgError } = await serviceClient
+    .from('organizations')
+    .upsert(BASE_ORG, { onConflict: 'id' })
+
+  if (orgError) {
+    throw new Error(`Failed to seed organization: ${orgError.message}`)
+  }
+
+  const { error: membershipsError } = await serviceClient
+    .from('memberships')
+    .upsert(BASE_MEMBERSHIPS, { onConflict: 'org_id,member_id' })
+
+  if (membershipsError) {
+    throw new Error(`Failed to seed memberships: ${membershipsError.message}`)
+  }
+}
+
+async function fetchAccessToken(role) {
+  if (tokenCache.has(role)) {
+    return tokenCache.get(role)
+  }
+
+  const user = USERS[role]
+  if (!user) {
+    throw new Error(`Unknown role: ${role}`)
+  }
+
+  const { data, error } = await serviceClient.auth.admin.generateLink({
+    type: 'magiclink',
+    email: user.email,
+  })
+
+  if (error) {
+    throw new Error(`Failed to generate OTP for ${role}: ${error.message}`)
+  }
+
+  const props = data?.properties
+
+  if (!props?.email_otp || !props?.verification_type) {
+    throw new Error(`OTP details missing for ${role}`)
+  }
+
+  const verifyResponse = await anonAuthClient.auth.verifyOtp({
+    email: user.email,
+    token: props.email_otp,
+    type: props.verification_type,
+  })
+
+  if (verifyResponse.error) {
+    throw new Error(
+      `Failed to verify OTP for ${role}: ${verifyResponse.error.message}`,
+    )
+  }
+
+  const accessToken = verifyResponse.data.session?.access_token
+
+  if (!accessToken) {
+    throw new Error(`No access token returned for ${role}`)
+  }
+
+  tokenCache.set(role, accessToken)
+  return accessToken
+}
+
+function createUserClient(token) {
+  return createClient(SUPABASE_URL, ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  })
+}
+
+async function getUserClient(role) {
+  if (clientCache.has(role)) {
+    return clientCache.get(role)
+  }
+
+  const token = await fetchAccessToken(role)
+  const client = createUserClient(token)
+  clientCache.set(role, client)
+  return client
+}
+
+async function findMembership(memberId) {
+  const { data, error } = await serviceClient
+    .from('memberships')
+    .select('org_id, member_id, role')
+    .eq('org_id', ORG_ID)
+    .eq('member_id', memberId)
+    .maybeSingle()
+
+  if (error && error.code !== 'PGRST116') {
+    throw new Error(`Membership lookup failed: ${error.message}`)
+  }
+
+  return data ?? null
+}
+
+async function runTest(name, testFn) {
+  try {
+    const message = await testFn()
+    console.log(`PASS ${name}${message ? ` - ${message}` : ''}`)
+    return true
+  } catch (error) {
+    console.error(`FAIL ${name} - ${error.message ?? error}`)
+    return false
+  }
+}
+
+await ensureBaselineData()
+
+const results = []
+
+results.push(
+  await runTest('customer can read org members', async () => {
+    const client = await getUserClient('customer')
+    const { data, error } = await client.rpc('get_org_members', { p_org: ORG_ID })
+
+    if (error) {
+      throw new Error(`get_org_members failed: ${error.message}`)
+    }
+
+    if (!Array.isArray(data) || data.length === 0) {
+      throw new Error('No memberships returned')
+    }
+
+    const customerEntry = data.find((row) => row.member_id === USERS.customer.id)
+
+    if (!customerEntry) {
+      throw new Error('Customer membership missing from response')
+    }
+
+    return `${data.length} memberships visible`
+  }),
+)
+
+results.push(
+  await runTest('agent can read org members', async () => {
+    const client = await getUserClient('agent')
+    const { data, error } = await client.rpc('get_org_members', { p_org: ORG_ID })
+
+    if (error) {
+      throw new Error(`get_org_members failed: ${error.message}`)
+    }
+
+    if (!Array.isArray(data) || data.length === 0) {
+      throw new Error('No memberships returned')
+    }
+
+    const agentEntry = data.find((row) => row.member_id === USERS.agent.id)
+
+    if (!agentEntry) {
+      throw new Error('Agent membership missing from response')
+    }
+
+    return `${data.length} memberships visible`
+  }),
+)
+
+results.push(
+  await runTest('admin can update agent role', async () => {
+    const client = await getUserClient('admin')
+    const { error } = await client.rpc('update_member_role', {
+      p_org: ORG_ID,
+      p_target: USERS.agent.id,
+      p_role: 'agent',
+    })
+
+    if (error) {
+      throw new Error(`update_member_role failed: ${error.message}`)
+    }
+
+    const membership = await findMembership(USERS.agent.id)
+
+    if (!membership) {
+      throw new Error('Agent membership missing after update')
+    }
+
+    if (membership.role !== 'agent') {
+      throw new Error(`Agent role is ${membership.role} after update`)
+    }
+
+    return 'Agent role unchanged as expected'
+  }),
+)
+
+results.push(
+  await runTest('customer cannot delete members', async () => {
+    const client = await getUserClient('customer')
+    const response = await client.rpc('delete_member', {
+      p_org: ORG_ID,
+      p_target: USERS.agent.id,
+    })
+
+    if (!response.error) {
+      await ensureBaselineData()
+      throw new Error('delete_member succeeded for customer')
+    }
+
+    const membership = await findMembership(USERS.agent.id)
+
+    if (!membership) {
+      await ensureBaselineData()
+      throw new Error('Agent membership removed by customer action')
+    }
+
+    return `Denied with: ${response.error.message}`
+  }),
+)
+
+results.push(
+  await runTest('admin can delete members', async () => {
+    const client = await getUserClient('admin')
+    const { error } = await client.rpc('delete_member', {
+      p_org: ORG_ID,
+      p_target: USERS.agent.id,
+    })
+
+    if (error) {
+      throw new Error(`delete_member failed: ${error.message}`)
+    }
+
+    const membership = await findMembership(USERS.agent.id)
+
+    if (membership) {
+      throw new Error('Agent membership still exists after delete')
+    }
+
+    await ensureBaselineData()
+    return 'Agent membership removed and restored'
+  }),
+)
+
+const hasFailure = results.some((success) => !success)
+
+if (hasFailure) {
+  process.exitCode = 1
+} else {
+  console.log('All permission tests passed')
+}


### PR DESCRIPTION
## Summary
- add a Git patch that introduces RLS policies, refreshed RPC definitions, seed data, and schema reload notifications
- document local permission validation steps and add a Node.js test runner that exercises the new RPC permissions
- provide a helper script to apply the stored patch files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9cbea09988332b8fc4d88cc78f5d8