### PR TITLE
Fix delete_member RLS enforcement

### DIFF
--- a/supabase/migrations/20240522153000_fix_delete_member_rls.sql
+++ b/supabase/migrations/20240522153000_fix_delete_member_rls.sql
@@ -1,0 +1,22 @@
+-- Ensure delete_member runs with the caller's permissions so RLS applies
+alter function public.delete_member(p_org uuid, p_target uuid)
+  security invoker;
+
+-- Only admins of the same organization may delete memberships
+drop policy if exists "Admins can delete org memberships" on public.memberships;
+
+create policy "Admins can delete org memberships"
+  on public.memberships
+  for delete
+  using (
+    exists (
+      select 1
+      from public.memberships as admin_membership
+      where admin_membership.org_id = memberships.org_id
+        and admin_membership.member_id = auth.uid()
+        and upper(admin_membership.role::text) = 'ADMIN'
+    )
+  );
+
+-- Allow authenticated users to attempt deletes (enforced by RLS above)
+grant delete on table public.memberships to authenticated;


### PR DESCRIPTION
## Summary
- switch delete_member to SECURITY INVOKER so row level security is enforced
- add an admin-only delete policy on public.memberships and grant delete to authenticated

## Testing
- not run (SQL-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9dfb9b5848332996cd3b4406d6982