### PR TITLE
Ensure only admins can delete memberships

### DIFF
--- a/README_DB_DELETE.md
+++ b/README_DB_DELETE.md
@@ -1,0 +1,8 @@
+Korte stappen:
+
+supabase db reset
+
+supabase db connect en voer:
+\\i scripts/db-diagnose-delete.sql
+
+Verwacht: alleen policy admin_delete_membership voor DELETE, en security_definer = false voor delete_member(uuid,uuid).

--- a/scripts/db-diagnose-delete.sql
+++ b/scripts/db-diagnose-delete.sql
@@ -1,0 +1,11 @@
+-- Overview of DELETE policies on public.memberships
+select schemaname, tablename, policyname, cmd, roles, qual
+from pg_policies
+where schemaname = 'public' and tablename = 'memberships'
+order by cmd, policyname;
+
+-- Security mode of delete_member function
+select p.proname, p.prosecdef as security_definer, p.proargtypes::regtype[] as args
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'public' and p.proname = 'delete_member';

--- a/supabase/migrations/20240614120000_fix_memberships_delete.sql
+++ b/supabase/migrations/20240614120000_fix_memberships_delete.sql
@@ -1,0 +1,58 @@
+-- Enable row level security on memberships
+alter table if exists public.memberships
+  enable row level security;
+
+-- Drop all existing DELETE policies on public.memberships
+DO $$
+DECLARE
+  policy record;
+BEGIN
+  FOR policy IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'memberships'
+      AND cmd = 'DELETE'
+  LOOP
+    EXECUTE format('drop policy if exists %I on public.memberships', policy.policyname);
+  END LOOP;
+END
+$$;
+
+drop policy if exists admin_delete_membership on public.memberships;
+create policy admin_delete_membership
+on public.memberships
+for delete
+to authenticated
+using (
+  exists (
+    select 1
+    from public.memberships m
+    where m.org_id = memberships.org_id
+      and m.member_id = auth.uid()
+      and m.role = 'admin'
+  )
+);
+
+-- Ensure delete_member RPC runs with caller's privileges
+DO $$
+DECLARE
+  fn record;
+BEGIN
+  FOR fn IN
+    SELECT format('alter function public.delete_member(%s) security invoker',
+                  pg_get_function_identity_arguments(p.oid)) AS ddl
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'delete_member'
+  LOOP
+    EXECUTE fn.ddl;
+  END LOOP;
+END
+$$;
+
+revoke all on function public.delete_member(uuid, uuid) from anon;
+grant execute on function public.delete_member(uuid, uuid) to authenticated;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- enable row level security for `public.memberships` delete operations and replace policies with an admin-only rule
- force all `delete_member` RPC overloads to run as security invoker and align privileges for authenticated users
- document verification steps and add a diagnostic script for inspecting delete policies and function security

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9e2ac1f14833282394afdd29318ea