### PR TITLE
Add core Supabase migration

### DIFF
--- a/supabase/migrations/202407101100_create_core.sql
+++ b/supabase/migrations/202407101100_create_core.sql
@@ -1,0 +1,33 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.organizations (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.memberships (
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  member_id uuid not null references auth.users(id) on delete cascade,
+  role text not null check (role in ('admin','agent','customer')),
+  created_at timestamptz default now(),
+  primary key (org_id, member_id)
+);
+
+create table if not exists public.invites (
+  id uuid primary key,
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  email text not null,
+  role text not null check (role in ('admin','agent','customer')),
+  created_at timestamptz default now()
+);
+
+create table if not exists public.chats (
+  id uuid primary key default gen_random_uuid(),
+  org_id uuid not null references public.organizations(id) on delete cascade,
+  owner_id uuid not null references auth.users(id) on delete cascade,
+  body jsonb,
+  created_at timestamptz default now()
+);
+
+-- geen RLS of policies hier, alleen schema


### PR DESCRIPTION
## Summary
- add a core Supabase migration defining organizations, memberships, invites, and chats tables
- ensure pgcrypto extension is available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9e6a0b5b483329da1eddbdefcba78