### PR TITLE
Fix MembersAdmin update handler respects 204 and refreshes list

### DIFF
--- a/.codex/patches/membersadmin-update-handler.patch
+++ b/.codex/patches/membersadmin-update-handler.patch
@@ -1,0 +1,36 @@
+diff --git a/src/components/MembersAdmin.jsx b/src/components/MembersAdmin.jsx
+index 74745b5..ec5c356 100644
+--- a/src/components/MembersAdmin.jsx
++++ b/src/components/MembersAdmin.jsx
+@@ -96,20 +96,28 @@ export default function MembersAdmin() {
+-  async function changeRole(userId, newRole) {
++  async function changeRole(userId, nextRole) {
+     setBusyUser(userId);
+-    const { data, error } = await supabase.rpc('update_member_role', {
++    const { error } = await supabase.rpc('update_member_role', {
+       p_org: activeOrgId,
+       p_target: userId,
+-      p_role: newRole,
++      p_role: nextRole,
+     });
+     setBusyUser(null);
+-    if (error || data !== true) {
+-      console.warn('[MembersAdmin] update_member_role failed', { org: activeOrgId, target: userId, error });
+-      alert('Wijzigen mislukt: ' + (error?.message || 'geen recht')); return;
++    if (!error) {
++      await fetchMembers();
++      setToast('Rol bijgewerkt');
++      return;
+     }
+-    setRows(r => r.map(x => x.user_id === userId ? { ...x, role: newRole } : x));
+-    setToast('Rol bijgewerkt');
++
++    console.warn('[MembersAdmin] update_member_role failed', {
++      org: activeOrgId,
++      target: userId,
++      nextRole,
++      code: error?.code,
++      error,
++    });
++    alert('Wijzigen mislukt: ' + (error?.message || 'geen recht'));
+   }

--- a/src/components/MembersAdmin.jsx
+++ b/src/components/MembersAdmin.jsx
@@ -96,20 +96,28 @@ export default function MembersAdmin() {
   }
   useEffect(()=>{ fetchMembers(); /* eslint-disable-next-line */ },[activeOrgId]);
 
-  async function changeRole(userId, newRole) {
+  async function changeRole(userId, nextRole) {
     setBusyUser(userId);
-    const { data, error } = await supabase.rpc('update_member_role', {
+    const { error } = await supabase.rpc('update_member_role', {
       p_org: activeOrgId,
       p_target: userId,
-      p_role: newRole,
+      p_role: nextRole,
     });
     setBusyUser(null);
-    if (error || data !== true) {
-      console.warn('[MembersAdmin] update_member_role failed', { org: activeOrgId, target: userId, error });
-      alert('Wijzigen mislukt: ' + (error?.message || 'geen recht')); return;
+    if (!error) {
+      await fetchMembers();
+      setToast('Rol bijgewerkt');
+      return;
     }
-    setRows(r => r.map(x => x.user_id === userId ? { ...x, role: newRole } : x));
-    setToast('Rol bijgewerkt');
+
+    console.warn('[MembersAdmin] update_member_role failed', {
+      org: activeOrgId,
+      target: userId,
+      nextRole,
+      code: error?.code,
+      error,
+    });
+    alert('Wijzigen mislukt: ' + (error?.message || 'geen recht'));
   }
 
   function askRemove(userId, email){ setConfirm({ open:true, userId, email }); }


### PR DESCRIPTION
## Summary
- handle update_member_role RPC success when no error is returned
- refresh the member list and show the success toast after updating a role
- log detailed warnings including error codes and only alert on real errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca8ecce7cc8332810614941d09b62e