### PR TITLE
feat: Netlify functions respect Supabase RLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,45 @@
-# React + Vite
+# Blueline Chatpilot – Netlify Functions met Supabase RLS
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Deze app gebruikt Netlify Functions die altijd de Supabase **anon key** combineren met de user-JWT van de ingelogde gebruiker. Hierdoor blijven alle Row Level Security (RLS) policies actief en is er nooit een service-role key nodig vanuit de frontend.
 
-Currently, two official plugins are available:
+## Vereiste environment variabelen
+Maak lokaal een `.env` met onderstaande variabelen. Configureer dezelfde waarden in het Netlify dashboard.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```bash
+SUPABASE_URL="https://<project>.supabase.co"
+SUPABASE_ANON_KEY="<public-anon-key>"
+ALLOWED_ORIGINS="https://bluelineccs.nl,https://<live-site>.netlify.app,http://localhost:8888,http://localhost:5173"
+```
 
-## Expanding the ESLint configuration
+> Gebruik **nooit** de `SUPABASE_SERVICE_ROLE_KEY` voor deze functies. Alle requests krijgen het user-token mee via de `Authorization: Bearer <access_token>` header.
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+## Netlify Functions
+De map [`netlify/functions`](netlify/functions) bevat o.a.:
+
+- `getProfile.ts` – geeft het huidige profiel terug.
+- `listMemberships.ts` – toont memberships (optioneel gefilterd op `org_id`).
+- `updateMemberRole.ts` – wijzigt een rol via de `update_member_role` RPC en logt audit events.
+- `deleteMember.ts` – verwijdert een lid via de `delete_member` RPC met audit logging.
+
+Alle functies ondersteunen CORS/OPTIONS en accepteren alleen requests met een geldige Bearer token afkomstig van `supabase.auth.getSession()`.
+
+## Frontend gebruik
+De Members-admin gebruikt `/.netlify/functions/*` endpoints en stuurt automatisch de `Authorization` header mee. Rollen wijzigen of verwijderen triggert audit logging in Supabase.
+
+## Lokaal draaien en testen
+1. Installeer dependencies: `npm install`
+2. Start Netlify dev-server (frontend + functies):
+   ```bash
+   netlify dev
+   ```
+3. Test een endpoint met een geldige Supabase user access token:
+   ```bash
+   curl -i -H "Authorization: Bearer <USER_ACCESS_TOKEN>" http://localhost:8888/.netlify/functions/getProfile
+   curl -i -H "Authorization: Bearer <USER_ACCESS_TOKEN>" "http://localhost:8888/.netlify/functions/listMemberships?org_id=<uuid>"
+   ```
+4. Bouwcontrole voor de frontend:
+   ```bash
+   npm run build
+   ```
+
+Als je een andere origin gebruikt tijdens ontwikkeling, voeg die dan toe aan `ALLOWED_ORIGINS`.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,20 @@
 [build]
-  command   = "npm run build"
-  publish   = "dist"
+  command = "npm run build"
+  publish = "dist"
   functions = "netlify/functions"
+  node_bundler = "esbuild"
+
+[functions]
+  node_bundler = "esbuild"
+  external_node_modules = ["@supabase/supabase-js"]
+
+[[headers]]
+  for = "/.netlify/functions/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Headers = "authorization, content-type, x-requested-with"
+    Access-Control-Allow-Methods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+    Access-Control-Max-Age = "86400"
 
 [[redirects]]
   from = "/*"

--- a/netlify/functions/_shared/supabaseServer.ts
+++ b/netlify/functions/_shared/supabaseServer.ts
@@ -1,0 +1,34 @@
+import { createClient } from '@supabase/supabase-js';
+
+export function getAllowedOrigin(originHeader?: string) {
+  const env = process.env.ALLOWED_ORIGINS || '';
+  const allowlist = env.split(',').map(s => s.trim()).filter(Boolean);
+  if (!originHeader) return '*';
+  if (allowlist.length === 0) return '*';
+  return allowlist.includes(originHeader) ? originHeader : allowlist[0] || '*';
+}
+
+export function buildCorsHeaders(originHeader?: string) {
+  const allow = getAllowedOrigin(originHeader);
+  return {
+    'Access-Control-Allow-Origin': allow,
+    'Access-Control-Allow-Headers': 'authorization, content-type, x-requested-with',
+    'Access-Control-Allow-Methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+  };
+}
+
+export function supabaseForRequest(authorizationHeader?: string) {
+  const SUPABASE_URL = process.env.SUPABASE_URL!;
+  const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY!;
+  const token = (authorizationHeader || '').startsWith('Bearer ')
+    ? authorizationHeader!.slice('Bearer '.length)
+    : undefined;
+
+  const headers: Record<string, string> = {};
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+
+  return createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, detectSessionInUrl: false },
+    global: { headers },
+  });
+}

--- a/netlify/functions/deleteMember.ts
+++ b/netlify/functions/deleteMember.ts
@@ -1,0 +1,36 @@
+import type { Handler } from '@netlify/functions';
+import { supabaseForRequest, buildCorsHeaders } from './_shared/supabaseServer';
+
+export const handler: Handler = async (event) => {
+  const cors = buildCorsHeaders(event.headers.origin);
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors, body: '' };
+  if (event.httpMethod !== 'POST') return { statusCode: 405, headers: cors, body: JSON.stringify({ error: 'Method not allowed' }) };
+
+  const auth = event.headers.authorization;
+  if (!auth) return { statusCode: 401, headers: cors, body: JSON.stringify({ error: 'Missing Authorization Bearer token' }) };
+
+  const supabase = supabaseForRequest(auth);
+  const body = JSON.parse(event.body || '{}');
+  const { membership_id } = body;
+
+  if (!membership_id) {
+    return { statusCode: 400, headers: cors, body: JSON.stringify({ error: 'membership_id is required' }) };
+  }
+
+  const { error } = await supabase.rpc('delete_member', {
+    p_membership_id: membership_id,
+  });
+
+  // audit (best effort)
+  const { data: userInfo } = await supabase.auth.getUser().catch(() => ({ data: undefined as any }));
+  const actor = userInfo?.user?.id ?? null;
+  await supabase.from('audit_logs').insert({
+    actor_user_id: actor,
+    action: 'delete_member',
+    target: membership_id,
+    details: {},
+  }).catch(() => {});
+
+  if (error) return { statusCode: 400, headers: cors, body: JSON.stringify({ error: error.message }) };
+  return { statusCode: 200, headers: cors, body: JSON.stringify({ ok: true }) };
+};

--- a/netlify/functions/getProfile.ts
+++ b/netlify/functions/getProfile.ts
@@ -1,0 +1,16 @@
+import type { Handler } from '@netlify/functions';
+import { supabaseForRequest, buildCorsHeaders } from './_shared/supabaseServer';
+
+export const handler: Handler = async (event) => {
+  const cors = buildCorsHeaders(event.headers.origin);
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors, body: '' };
+
+  const auth = event.headers.authorization;
+  if (!auth) return { statusCode: 401, headers: cors, body: JSON.stringify({ error: 'Missing Authorization Bearer token' }) };
+
+  const supabase = supabaseForRequest(auth);
+  const { data, error } = await supabase.from('profiles').select('*').single();
+
+  if (error) return { statusCode: 400, headers: cors, body: JSON.stringify({ error: error.message }) };
+  return { statusCode: 200, headers: cors, body: JSON.stringify({ profile: data }) };
+};

--- a/netlify/functions/listMemberships.ts
+++ b/netlify/functions/listMemberships.ts
@@ -1,0 +1,21 @@
+import type { Handler } from '@netlify/functions';
+import { supabaseForRequest, buildCorsHeaders } from './_shared/supabaseServer';
+
+export const handler: Handler = async (event) => {
+  const cors = buildCorsHeaders(event.headers.origin);
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors, body: '' };
+
+  const auth = event.headers.authorization;
+  if (!auth) return { statusCode: 401, headers: cors, body: JSON.stringify({ error: 'Missing Authorization Bearer token' }) };
+
+  const supabase = supabaseForRequest(auth);
+  const orgId = event.queryStringParameters?.org_id ?? undefined;
+
+  let query = supabase.from('memberships').select('id, org_id, user_id, role, inserted_at');
+  if (orgId) query = query.eq('org_id', orgId);
+
+  const { data, error } = await query.order('inserted_at', { ascending: false });
+  if (error) return { statusCode: 400, headers: cors, body: JSON.stringify({ error: error.message }) };
+
+  return { statusCode: 200, headers: cors, body: JSON.stringify({ items: data }) };
+};

--- a/netlify/functions/updateMemberRole.ts
+++ b/netlify/functions/updateMemberRole.ts
@@ -1,0 +1,37 @@
+import type { Handler } from '@netlify/functions';
+import { supabaseForRequest, buildCorsHeaders } from './_shared/supabaseServer';
+
+export const handler: Handler = async (event) => {
+  const cors = buildCorsHeaders(event.headers.origin);
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors, body: '' };
+  if (event.httpMethod !== 'POST') return { statusCode: 405, headers: cors, body: JSON.stringify({ error: 'Method not allowed' }) };
+
+  const auth = event.headers.authorization;
+  if (!auth) return { statusCode: 401, headers: cors, body: JSON.stringify({ error: 'Missing Authorization Bearer token' }) };
+
+  const supabase = supabaseForRequest(auth);
+  const body = JSON.parse(event.body || '{}');
+  const { membership_id, new_role } = body;
+
+  if (!membership_id || !new_role) {
+    return { statusCode: 400, headers: cors, body: JSON.stringify({ error: 'membership_id and new_role are required' }) };
+  }
+
+  const { data, error } = await supabase.rpc('update_member_role', {
+    p_membership_id: membership_id,
+    p_new_role: new_role,
+  });
+
+  // audit (best effort)
+  const { data: userInfo } = await supabase.auth.getUser().catch(() => ({ data: undefined as any }));
+  const actor = userInfo?.user?.id ?? null;
+  await supabase.from('audit_logs').insert({
+    actor_user_id: actor,
+    action: 'update_member_role',
+    target: membership_id,
+    details: { new_role },
+  }).catch(() => {});
+
+  if (error) return { statusCode: 400, headers: cors, body: JSON.stringify({ error: error.message }) };
+  return { statusCode: 200, headers: cors, body: JSON.stringify({ ok: true, result: data }) };
+};


### PR DESCRIPTION
## Summary
- add shared Supabase client helper and Netlify functions for profile, membership listing, and membership mutations using user JWTs
- update MembersAdmin UI to call the new Netlify endpoints with Authorization headers and preserve audit logging
- document required environment variables, local testing steps, and configure Netlify bundling and headers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc4d4f2364833295e701f4f4f71532