### PR TITLE
fix(functions): add listMemberships (RLS, GET)

### DIFF
--- a/netlify/functions/_shared/supabaseServer.ts
+++ b/netlify/functions/_shared/supabaseServer.ts
@@ -1,0 +1,55 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+type SupabaseHeaders = {
+  Authorization: string;
+};
+
+type SupabaseOptions = {
+  auth: {
+    persistSession: false;
+    autoRefreshToken: false;
+  };
+  global: {
+    headers: SupabaseHeaders;
+  };
+};
+
+function extractBearerToken(authHeader: string) {
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return (match ? match[1] : authHeader).trim();
+}
+
+export function supabaseForRequest(authHeader: string): SupabaseClient {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Missing SUPABASE_URL or SUPABASE_ANON_KEY env vars');
+  }
+
+  const token = extractBearerToken(authHeader);
+
+  const options: SupabaseOptions = {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+    global: {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    },
+  };
+
+  return createClient(supabaseUrl, supabaseAnonKey, options);
+}
+
+export function buildCorsHeaders(origin?: string | null) {
+  const allowOrigin = origin ?? '*';
+  return {
+    'Access-Control-Allow-Origin': allowOrigin,
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    Vary: 'Origin',
+  } as const;
+}

--- a/netlify/functions/listMemberships.ts
+++ b/netlify/functions/listMemberships.ts
@@ -1,0 +1,25 @@
+import type { Handler } from '@netlify/functions';
+import { supabaseForRequest, buildCorsHeaders } from './_shared/supabaseServer';
+
+export const handler: Handler = async (event) => {
+  const cors = buildCorsHeaders(event.headers.origin);
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: cors, body: '' };
+  if (event.httpMethod !== 'GET') return { statusCode: 405, headers: cors, body: JSON.stringify({ error: 'Use GET' }) };
+
+  const auth = event.headers.authorization;
+  if (!auth) return { statusCode: 401, headers: cors, body: JSON.stringify({ error: 'Missing Authorization header' }) };
+
+  const supabase = supabaseForRequest(auth);
+  const orgId = event.queryStringParameters?.org_id;
+  if (!orgId) return { statusCode: 400, headers: cors, body: JSON.stringify({ error: 'Missing org_id' }) };
+
+  // RLS: user-JWT enforced by anon client
+  const { data, error } = await supabase
+    .from('memberships')
+    .select('org_id, user_id, role, created_at')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false });
+
+  if (error) return { statusCode: 400, headers: cors, body: JSON.stringify({ error: error.message }) };
+  return { statusCode: 200, headers: cors, body: JSON.stringify({ items: data }) };
+};


### PR DESCRIPTION
## Summary
- add shared supabase helper for Netlify functions to bootstrap Supabase clients and CORS headers
- add listMemberships Netlify function that lists org memberships with RLS-enforced GET handler

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdac43e1bc8332801313ff92b3e2f7