### PR TITLE
fix(rls): enforce RLS via Netlify Functions + UI routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,56 @@
-# React + Vite
+# Blueline Chatpilot
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Blueline Chatpilot gebruikt Netlify Functions als beveiligde proxy richting Supabase. Alle ledenbeheer-acties (lijst, rol aanpassen, verwijderen) gaan via deze laag en sturen het Supabase user-JWT als `Authorization: Bearer ...` mee zodat Row Level Security (RLS) altijd wordt afgedwongen in development, deploy previews en productie.
 
-Currently, two official plugins are available:
+## Netlify & Supabase configuratie
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+| Variabele              | Contexten                                | Opmerkingen |
+| ---------------------- | ---------------------------------------- | ----------- |
+| `SUPABASE_URL`         | Production, Deploy Preview, Netlify CLI  | Supabase project URL |
+| `SUPABASE_ANON_KEY`    | Production, Deploy Preview, Netlify CLI  | Publieke (anon) API key |
 
-## Expanding the ESLint configuration
+> Zorg dat **niet** de service-role key wordt gebruikt in clients of Netlify Functions. De functions injecteren automatisch de user access token in `Authorization` zodat Supabase RLS policies blijven gelden.
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Netlify bundelt de functions met esbuild (`netlify.toml`) en verwacht de bronbestanden in `netlify/functions/`. Wanneer je lokaal via `netlify dev` draait, zet dezelfde env vars in `.env` of je shell.
+
+## Smoke test voor RLS
+
+`scripts/smoke-rls.mjs` verifieert de kritieke paden:
+
+1. Admin kan via `/updateMemberRole` een rol wijzigen (200).
+2. Niet-admin en requests zonder token krijgen een 401/403.
+3. Admin kan `/deleteMember` aanroepen (optioneel te skippen).
+4. Een OPTIONS-preflight geeft CORS-headers terug.
+
+Gebruik:
+
+```bash
+export ADMIN_ACCESS_TOKEN="<admin_jwt>"
+export USER_ACCESS_TOKEN="<member_jwt>"
+export ORG_ID="<org_uuid>"
+export TARGET_USER_ID="<target_user_uuid>"
+# Optioneel:
+# export RLS_BASE_URL="https://deploy-preview-123--example.netlify.app/.netlify/functions"
+# export RLS_SKIP_DELETE=1   # sla delete rooktest over
+# export RLS_ROLE=TEAM       # gewenste rol voor de update rooktest
+
+node scripts/smoke-rls.mjs
+```
+
+De `BASE_URL` wijst standaard naar `http://localhost:9999/.netlify/functions` zodat de test zowel tegen `netlify dev` als tegen een deploy preview kan draaien.
+
+## Lokale ontwikkeling
+
+```bash
+npm install
+npm run dev
+```
+
+Configureer je lokale Supabase connectie via een `.env.local` voor Vite:
+
+```
+VITE_SUPABASE_URL=...
+VITE_SUPABASE_ANON_KEY=...
+```
+
+De UI gebruikt `netlifyJson()` helpers om ledenbeheer-acties naar `/.netlify/functions/*` te sturen; val niet terug op directe Supabase-mutaties zodat RLS gehandhaafd blijft.

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,9 @@
   publish   = "dist"
   functions = "netlify/functions"
 
+[functions]
+  node_bundler = "esbuild"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/functions/getProfile.ts
+++ b/netlify/functions/getProfile.ts
@@ -1,0 +1,100 @@
+import { createClient } from '@supabase/supabase-js';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8' } as const;
+
+function corsHeaders(request: Request) {
+  const origin = request.headers.get('origin') || '*';
+  return { 'Access-Control-Allow-Origin': origin, Vary: 'Origin' };
+}
+
+function extractBearerToken(headerValue: string | null) {
+  if (!headerValue) return null;
+  const match = headerValue.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  return match[1]?.trim() || null;
+}
+
+function missingEnvResponse(request: Request) {
+  return new Response(
+    JSON.stringify({ error: 'Missing SUPABASE_URL or SUPABASE_ANON_KEY env vars' }),
+    {
+      status: 500,
+      headers: { ...JSON_HEADERS, ...corsHeaders(request) },
+    }
+  );
+}
+
+function optionsResponse(request: Request) {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      ...corsHeaders(request),
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Max-Age': '86400',
+    },
+  });
+}
+
+function buildErrorResponse(request: Request, status: number, error: unknown, code?: string) {
+  const message =
+    (typeof error === 'string' && error) ||
+    (error && typeof error === 'object' && 'message' in error && typeof (error as any).message === 'string'
+      ? (error as any).message
+      : 'Onbekende fout');
+
+  const details =
+    error && typeof error === 'object' && 'details' in error && typeof (error as any).details === 'string'
+      ? (error as any).details
+      : undefined;
+
+  const payload: Record<string, unknown> = { error: message };
+  if (code) payload.code = code;
+  if (details) payload.details = details;
+
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...JSON_HEADERS, ...corsHeaders(request) },
+  });
+}
+
+export default async function handler(request: Request) {
+  if (request.method === 'OPTIONS') return optionsResponse(request);
+
+  if (request.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'Use GET' }), {
+      status: 405,
+      headers: { ...JSON_HEADERS, ...corsHeaders(request) },
+    });
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !anonKey) return missingEnvResponse(request);
+
+  const token = extractBearerToken(request.headers.get('authorization'));
+  if (!token) {
+    return buildErrorResponse(request, 401, 'Missing Authorization header', 'NO_TOKEN');
+  }
+
+  const supabase = createClient(supabaseUrl, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  });
+
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error) {
+      const status = typeof (error as any).status === 'number' ? (error as any).status : 400;
+      return buildErrorResponse(request, status, error, (error as any).code);
+    }
+
+    return new Response(JSON.stringify({ user: data?.user ?? null }), {
+      status: 200,
+      headers: { ...JSON_HEADERS, ...corsHeaders(request) },
+    });
+  } catch (err) {
+    console.error('[getProfile] unexpected error', err);
+    return buildErrorResponse(request, 500, 'Unexpected server error', 'SERVER_ERROR');
+  }
+}

--- a/netlify/functions/listMemberships.ts
+++ b/netlify/functions/listMemberships.ts
@@ -1,0 +1,116 @@
+import { createClient } from '@supabase/supabase-js';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json; charset=utf-8' } as const;
+
+function corsHeaders(request: Request) {
+  const origin = request.headers.get('origin') || '*';
+  return { 'Access-Control-Allow-Origin': origin, Vary: 'Origin' };
+}
+
+function extractBearerToken(headerValue: string | null) {
+  if (!headerValue) return null;
+  const match = headerValue.match(/^Bearer\s+(.+)$/i);
+  if (!match) return null;
+  return match[1]?.trim() || null;
+}
+
+function missingEnvResponse(request: Request) {
+  return new Response(
+    JSON.stringify({ error: 'Missing SUPABASE_URL or SUPABASE_ANON_KEY env vars' }),
+    {
+      status: 500,
+      headers: { ...JSON_HEADERS, ...corsHeaders(request) },
+    }
+  );
+}
+
+function optionsResponse(request: Request) {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      ...corsHeaders(request),
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Max-Age': '86400',
+    },
+  });
+}
+
+function buildErrorResponse(request: Request, status: number, error: unknown, code?: string) {
+  const message =
+    (typeof error === 'string' && error) ||
+    (error && typeof error === 'object' && 'message' in error && typeof (error as any).message === 'string'
+      ? (error as any).message
+      : 'Onbekende fout');
+
+  const details =
+    error && typeof error === 'object' && 'details' in error && typeof (error as any).details === 'string'
+      ? (error as any).details
+      : undefined;
+
+  const payload: Record<string, unknown> = { error: message };
+  if (code) payload.code = code;
+  if (details) payload.details = details;
+
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { ...JSON_HEADERS, ...corsHeaders(request) },
+  });
+}
+
+export default async function handler(request: Request) {
+  if (request.method === 'OPTIONS') return optionsResponse(request);
+
+  if (request.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'Use GET' }), {
+      status: 405,
+      headers: { ...JSON_HEADERS, ...corsHeaders(request) },
+    });
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const anonKey = process.env.SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !anonKey) return missingEnvResponse(request);
+
+  const token = extractBearerToken(request.headers.get('authorization'));
+  if (!token) {
+    return buildErrorResponse(request, 401, 'Missing Authorization header', 'NO_TOKEN');
+  }
+
+  const { searchParams } = new URL(request.url);
+  const orgId = searchParams.get('org_id')?.trim();
+  if (!orgId) {
+    return buildErrorResponse(request, 400, 'Query parameter org_id is required', 'BAD_REQUEST');
+  }
+
+  const supabase = createClient(supabaseUrl, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { Authorization: `Bearer ${token}` } },
+  });
+
+  try {
+    const { data, error } = await supabase.rpc('get_org_members', { p_org: orgId });
+    if (error) {
+      const status = typeof (error as any).status === 'number' ? (error as any).status : 400;
+      return buildErrorResponse(request, status, error, (error as any).code);
+    }
+
+    const items = Array.isArray(data)
+      ? data.map((row: Record<string, any>) => ({
+          org_id: row.org_id ?? orgId,
+          user_id: row.user_id ?? row.member_id ?? null,
+          role: row.role ?? null,
+          email: row.email ?? row.user_email ?? null,
+          created_at: row.created_at ?? null,
+        }))
+      : [];
+
+    return new Response(JSON.stringify({ items }), {
+      status: 200,
+      headers: { ...JSON_HEADERS, ...corsHeaders(request) },
+    });
+  } catch (err) {
+    console.error('[listMemberships] unexpected error', err);
+    return buildErrorResponse(request, 500, 'Unexpected server error', 'SERVER_ERROR');
+  }
+}

--- a/scripts/smoke-rls.mjs
+++ b/scripts/smoke-rls.mjs
@@ -1,90 +1,159 @@
 #!/usr/bin/env node
 import process from 'node:process';
 
-const REQUIRED_ENVS = ['RLS_BASE_URL', 'RLS_USER_TOKEN', 'RLS_ORG_ID', 'RLS_TARGET_ID'];
-const missing = REQUIRED_ENVS.filter((key) => !process.env[key] || !process.env[key]?.trim());
+const DEFAULT_BASE_URL = 'http://localhost:9999/.netlify/functions';
+const BASE_URL = (process.env.RLS_BASE_URL || process.env.SMOKE_BASE_URL || DEFAULT_BASE_URL).replace(/\/$/, '');
+const ADMIN_TOKEN = process.env.ADMIN_ACCESS_TOKEN || process.env.RLS_ADMIN_TOKEN;
+const USER_TOKEN = process.env.USER_ACCESS_TOKEN || process.env.RLS_USER_TOKEN;
+const ORG_ID = process.env.ORG_ID || process.env.RLS_ORG_ID;
+const TARGET_USER_ID = process.env.TARGET_USER_ID || process.env.RLS_TARGET_ID;
+const ROLE = process.env.RLS_ROLE || process.env.SMOKE_ROLE || 'TEAM';
+const SKIP_DELETE = process.env.RLS_SKIP_DELETE === '1' || process.env.SMOKE_SKIP_DELETE === '1';
 
+const REQUIRED_ENVS = [
+  ['ADMIN_ACCESS_TOKEN', ADMIN_TOKEN],
+  ['USER_ACCESS_TOKEN', USER_TOKEN],
+  ['ORG_ID', ORG_ID],
+  ['TARGET_USER_ID', TARGET_USER_ID],
+];
+
+const missing = REQUIRED_ENVS.filter(([, value]) => !value || !String(value).trim()).map(([key]) => key);
 if (missing.length) {
   console.error('Missing required environment variables:', missing.join(', '));
-  console.error(
-    '\nStel bijvoorbeeld in:\n' +
-      '  export RLS_BASE_URL="http://localhost:8888"\n' +
-      '  export RLS_USER_TOKEN="<supabase_user_jwt>"\n' +
-      '  export RLS_ORG_ID="<org_uuid>"\n' +
-      '  export RLS_TARGET_ID="<target_user_uuid>"\n' +
-      '  export RLS_ROLE="TEAM"\n' +
-      '  export RLS_SKIP_DELETE="1"  # optioneel, om delete te skippen'
-  );
+  console.error('\nExample usage:');
+  console.error('  export ADMIN_ACCESS_TOKEN="<admin_jwt>"');
+  console.error('  export USER_ACCESS_TOKEN="<member_jwt>"');
+  console.error('  export ORG_ID="<org_uuid>"');
+  console.error('  export TARGET_USER_ID="<target_user_uuid>"');
+  console.error('  export RLS_BASE_URL="http://localhost:9999/.netlify/functions"  # optional');
+  console.error('  node scripts/smoke-rls.mjs');
   process.exit(1);
 }
 
-const BASE_URL = process.env.RLS_BASE_URL;
-const USER_TOKEN = process.env.RLS_USER_TOKEN;
-const ORG_ID = process.env.RLS_ORG_ID;
-const TARGET_ID = process.env.RLS_TARGET_ID;
-const ROLE = process.env.RLS_ROLE || 'TEAM';
-const SKIP_DELETE = process.env.RLS_SKIP_DELETE === '1';
+function endpointUrl(name) {
+  return `${BASE_URL}/${name}`;
+}
 
-async function callEndpoint(name, payload) {
-  const url = new URL(`/.netlify/functions/${name}`, BASE_URL);
-  const resp = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${USER_TOKEN}`,
-    },
-    body: JSON.stringify(payload),
-  });
-
-  const data = await resp.json().catch(() => ({}));
-  if (!resp.ok || (data && typeof data === 'object' && data.error)) {
-    const message =
-      (data && typeof data === 'object' && typeof data.error === 'string' && data.error) ||
-      (data && typeof data === 'object' && data.error && typeof data.error.message === 'string' && data.error.message) ||
-      resp.statusText ||
-      'Onbekende fout';
-    const error = new Error(message);
-    error.code = (data && typeof data === 'object' && data.code) || resp.status;
-    error.response = data;
-    throw error;
+async function request(name, { method = 'POST', token, body } = {}) {
+  const init = { method, headers: {} };
+  if (method !== 'GET' && method !== 'HEAD' && body !== undefined) {
+    init.body = typeof body === 'string' ? body : JSON.stringify(body);
+    init.headers['Content-Type'] = 'application/json';
   }
+  if (token) init.headers.Authorization = `Bearer ${token}`;
 
-  return data;
+  const response = await fetch(endpointUrl(name), init);
+  const text = await response.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { response, json };
+}
+
+function logResult(ok, label, message) {
+  if (ok) {
+    console.log(`  ✓ ${label}${message ? ` — ${message}` : ''}`);
+  } else {
+    console.error(`  ✗ ${label}${message ? ` — ${message}` : ''}`);
+  }
 }
 
 async function main() {
-  console.log('→ updateMemberRole rooktest');
+  console.log('Smoke test base URL:', BASE_URL);
+
+  // Admin updateMemberRole (should succeed)
+  console.log('\n→ ADMIN updateMemberRole');
   try {
-    const res = await callEndpoint('updateMemberRole', {
-      p_org: ORG_ID,
-      p_target: TARGET_ID,
-      p_role: ROLE,
+    const { response, json } = await request('updateMemberRole', {
+      token: ADMIN_TOKEN,
+      body: { p_org: ORG_ID, p_target: TARGET_USER_ID, p_role: ROLE },
     });
-    console.log('  ✓ update_member_role OK', res);
+    const ok = response.ok && response.status === 200;
+    logResult(ok, 'Admin can update role', `status ${response.status}`);
+    if (!ok) {
+      console.error('    Response body:', json);
+      process.exitCode = 1;
+    }
   } catch (error) {
-    console.error('  ✗ update_member_role failed', error.message, error.response ?? '');
+    logResult(false, 'Admin can update role', error.message);
+    process.exitCode = 1;
+  }
+
+  // Member updateMemberRole (should be denied)
+  console.log('\n→ MEMBER updateMemberRole (expect 401/403)');
+  try {
+    const { response, json } = await request('updateMemberRole', {
+      token: USER_TOKEN,
+      body: { p_org: ORG_ID, p_target: TARGET_USER_ID, p_role: ROLE },
+    });
+    const denied = !response.ok && [401, 403].includes(response.status);
+    logResult(denied, 'Member blocked from updating role', `status ${response.status}`);
+    if (!denied) {
+      console.error('    Response body:', json);
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    logResult(false, 'Member blocked from updating role', error.message);
+    process.exitCode = 1;
+  }
+
+  // Missing token updateMemberRole (should be denied)
+  console.log('\n→ No token updateMemberRole (expect 401)');
+  try {
+    const { response, json } = await request('updateMemberRole', {
+      body: { p_org: ORG_ID, p_target: TARGET_USER_ID, p_role: ROLE },
+    });
+    const denied = !response.ok && response.status === 401;
+    logResult(denied, 'Missing token rejected', `status ${response.status}`);
+    if (!denied) {
+      console.error('    Response body:', json);
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    logResult(false, 'Missing token rejected', error.message);
     process.exitCode = 1;
   }
 
   if (SKIP_DELETE) {
-    console.log('→ deleteMember rooktest overgeslagen (RLS_SKIP_DELETE=1)');
-    return;
+    console.log('\n→ ADMIN deleteMember (skipped: RLS_SKIP_DELETE=1)');
+  } else {
+    console.log('\n→ ADMIN deleteMember');
+    try {
+      const { response, json } = await request('deleteMember', {
+        token: ADMIN_TOKEN,
+        body: { p_org: ORG_ID, p_target: TARGET_USER_ID },
+      });
+      const ok = response.ok && response.status === 200;
+      logResult(ok, 'Admin can delete member', `status ${response.status}`);
+      if (!ok) {
+        console.error('    Response body:', json);
+        process.exitCode = 1;
+      }
+    } catch (error) {
+      logResult(false, 'Admin can delete member', error.message);
+      process.exitCode = 1;
+    }
   }
 
-  console.log('→ deleteMember rooktest');
+  console.log('\n→ OPTIONS preflight updateMemberRole');
   try {
-    const res = await callEndpoint('deleteMember', {
-      p_org: ORG_ID,
-      p_target: TARGET_ID,
-    });
-    console.log('  ✓ delete_member OK', res);
+    const { response } = await request('updateMemberRole', { method: 'OPTIONS' });
+    const allowOrigin = response.headers.get('access-control-allow-origin');
+    const ok = (response.status === 200 || response.status === 204) && !!allowOrigin;
+    logResult(ok, 'Preflight returns CORS headers', `status ${response.status}, allow-origin=${allowOrigin}`);
+    if (!ok) {
+      process.exitCode = 1;
+    }
   } catch (error) {
-    console.error('  ✗ delete_member failed', error.message, error.response ?? '');
+    logResult(false, 'Preflight returns CORS headers', error.message);
     process.exitCode = 1;
   }
 }
 
-main().catch((err) => {
-  console.error('Onverwachte fout in rooktest:', err);
+main().catch((error) => {
+  console.error('Unexpected smoke test failure:', error);
   process.exit(1);
 });


### PR DESCRIPTION
ANALYSE
- Functions-laag
  - ❌ `getProfile` ontbrak onder `netlify/functions/`.
  - ❌ `listMemberships` ontbrak onder `netlify/functions/` (UI riep het pad wel aan).
  - ✅ `updateMemberRole` en `deleteMember` handlen `OPTIONS`, gebruiken de ANON key en forwarden `Authorization: Bearer <user token>`; lezen `SUPABASE_URL` en `SUPABASE_ANON_KEY`.
- RPC-signatures
  - ✅ `update_member_role(p_org uuid, p_target uuid, p_role text)` (202407101200_rls_and_rpcs.sql) — functies sturen `{ p_org, p_target, p_role }` mee.
  - ✅ `delete_member(p_org uuid, p_target uuid)` (20250916225048_fix_delete_member_hard.sql) — functies sturen `{ p_org, p_target }` mee.
- UI-callsites
  - ✅ `MembersAdmin` gebruikt `netlifyJson` + `authHeader()` voor `listMemberships`, `updateMemberRole` en `deleteMember`.
  - ⚠️ `useMembership` en `AuthProvider` lezen nog direct uit `memberships` (read-only, laat RLS intact).
- Netlify config & env
  - ⚠️ `netlify.toml` miste expliciete esbuild-bundler en er was geen repo-documentatie over `SUPABASE_URL`/`SUPABASE_ANON_KEY` in alle contexten; geen ALLOWED_ORIGINS helper gevonden.
- RLS & policies
  - ✅ RLS staat aan op `public.memberships` (migraties 202407101200*, 20250916*).
  - ✅ RPC's draaien als SECURITY DEFINER/INVOKER en er is geen gebruik van de service-role key aangetroffen.
- Smoke-testdekking
  - ⚠️ `scripts/smoke-rls.mjs` testte alleen admin happy-flow en ondersteunde geen baseUrl/OPTIONS checks.

OPLOSSINGEN
- `netlify/functions/listMemberships.ts`: nieuwe GET-function met CORS, ANON client + user JWT doorzetting en mapping op `{ user_id, email }` vanuit `get_org_members`.
- `netlify/functions/getProfile.ts`: nieuwe GET-function die `supabase.auth.getUser(token)` gebruikt achter de proxy.
- `scripts/smoke-rls.mjs`: rooktest herschreven voor admin- en non-admin-cases, no-token, optionele delete, OPTIONS en configureerbare baseUrl.
- `netlify.toml`: esbuild-bundler vastgezet voor functions.
- `README.md`: Netlify/Supabase env-vereisten en rooktest-instructies vastgelegd.

RISICO’S
- Email-adressen moeten via `get_org_members` meekomen; wanneer de RPC enkel `member_id` terugstuurt valt de UI terug op het user-id.
- Deploy previews falen als `SUPABASE_URL`/`SUPABASE_ANON_KEY` niet in alle Netlify-contexten staan.
- Geen live-backend beschikbaar in deze omgeving → geen network-screenshot toegevoegd.

TESTNOTITIES
- `npm run build`
- `scripts/smoke-rls.mjs` niet uitgevoerd (geen geldige Supabase-tokens beschikbaar in deze omgeving).

ACCEPTATIE
- [✅] RLS enforced: functions gebruiken user-JWT en geen service-role.
- [✅] Admin kan rollen wijzigen/verwijderen via functions (codepad gecontroleerd, rooktest dekt scenario).
- [⚠️] Non-admin requests blokkeren met 401/403 — afgedekt in rooktest, maar script niet gedraaid in deze omgeving.
- [✅] OPTIONS requests leveren CORS-headers (geïmplementeerd in alle endpoints & rooktest). 
- [⚠️] `scripts/smoke-rls.mjs` uitvoer (200/401) — documentatie aanwezig maar niet gedraaid zonder tokens.


------
https://chatgpt.com/codex/tasks/task_e_68cdafa23d6083329e5a98b440ad47e9