### PR TITLE
Add invite email support and login redirect handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,14 @@ The Netlify functions expect the following environment variables to be available
 
 - `SUPABASE_URL`
 - `SUPABASE_ANON_KEY`
+- `RESEND_API_KEY` – secret Resend token used to send invite e-mails (optional but required for e-mail delivery)
+- `FROM_EMAIL` – from-address for invite e-mails (for example `invites@blueline-chatpilot.netlify.app`)
+- `APP_ORIGIN` – optional override for the application origin when generating invite links
 
 Configure them locally via a `.env` file or export them in your shell before running `netlify dev` or the smoke tests.
+
+On Netlify you can configure these via **Site settings → Environment variables**:
+
+- `RESEND_API_KEY = <your_resend_token>`
+- `FROM_EMAIL = invites@blueline-chatpilot.netlify.app` (or your own domain)
+- `APP_ORIGIN = https://blueline-chatpilot.netlify.app` (optional)

--- a/netlify/functions/_shared/email.ts
+++ b/netlify/functions/_shared/email.ts
@@ -1,0 +1,58 @@
+export type SendInviteParams = {
+  to: string;
+  acceptUrl: string;
+  from?: string;
+  brand?: string;
+};
+
+export type SendInviteResult =
+  | { sent: true }
+  | { sent: false; reason: 'missing_env' | 'api_error'; status?: number; body?: string };
+
+export async function sendInviteEmail(p: SendInviteParams): Promise<SendInviteResult> {
+  const RESEND_API_KEY = process.env.RESEND_API_KEY;
+  const FROM_EMAIL = p.from || process.env.FROM_EMAIL;
+  if (!RESEND_API_KEY || !FROM_EMAIL) {
+    return { sent: false, reason: 'missing_env' };
+  }
+
+  const html = `
+    <div style="font-family:system-ui,Segoe UI,Arial">
+      <h2>${p.brand || 'Blueline Chatpilot'}</h2>
+      <p>Je bent uitgenodigd om lid te worden. Klik op de knop hieronder om de uitnodiging te accepteren.</p>
+      <p><a href="${p.acceptUrl}"
+            style="display:inline-block;background:#2563eb;color:#fff;padding:10px 16px;border-radius:8px;text-decoration:none">
+         Uitnodiging accepteren
+      </a></p>
+      <p>Werkt de knop niet? Kopieer dan deze link:<br>${p.acceptUrl}</p>
+    </div>
+  `.trim();
+
+  try {
+    const resp = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${RESEND_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: FROM_EMAIL,
+        to: [p.to],
+        subject: `${p.brand || 'Blueline Chatpilot'} — Uitnodiging`,
+        html,
+      }),
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '');
+      return { sent: false, reason: 'api_error', status: resp.status, body: text };
+    }
+    return { sent: true };
+  } catch (error: any) {
+    return {
+      sent: false,
+      reason: 'api_error',
+      body: typeof error?.message === 'string' ? error.message : undefined,
+    };
+  }
+}

--- a/src/components/MembersAdmin.jsx
+++ b/src/components/MembersAdmin.jsx
@@ -182,8 +182,15 @@ export default function MembersAdmin() {
 
   function handleInviteResult(result) {
     if (!result) return;
-    if (result.sent && result.email) {
-      setToast(`Uitnodiging verstuurd naar ${result.email}`);
+    const emailInfo = result.emailInfo;
+    if (emailInfo?.attempted) {
+      if (emailInfo.sent && result.email) {
+        setToast(`Uitnodiging per e-mail verstuurd naar ${result.email}.`);
+      } else {
+        setToast('E-mail niet verstuurd, link gekopieerd.');
+      }
+    } else if (result.sendEmail === false) {
+      setToast('E-mail overslagen, link gekopieerd.');
     } else if (result.acceptUrl) {
       setToast('Invite link aangemaakt.');
     }

--- a/src/pages/AcceptInvite.jsx
+++ b/src/pages/AcceptInvite.jsx
@@ -9,26 +9,25 @@ export default function AcceptInvite() {
   const [status, setStatus] = useState('Bezig met uitnodiging accepteren...');
 
   useEffect(() => {
-    if (!token) return;
-
     (async () => {
-      try {
-        const k = Object.keys(localStorage).find(
-          (x) => x.startsWith('sb-') && x.endsWith('-auth-token')
+      if (!token) {
+        setStatus('Ongeldige link: token ontbreekt.');
+        return;
+      }
+
+      const k = Object.keys(localStorage).find(
+        (x) => x.startsWith('sb-') && x.endsWith('-auth-token')
+      );
+      const t = k ? JSON.parse(localStorage.getItem(k) || '{}').access_token : null;
+      if (!t) {
+        const next = encodeURIComponent(
+          window.location.pathname + window.location.search
         );
-        const raw = k ? localStorage.getItem(k) : null;
-        let t = null;
-        if (raw) {
-          try {
-            t = JSON.parse(raw).access_token ?? null;
-          } catch {
-            t = null;
-          }
-        }
-        if (!t) {
-          setStatus('Je bent niet ingelogd. Log in en probeer opnieuw.');
-          return;
-        }
+        window.location.assign(`/login?next=${next}`);
+        return;
+      }
+
+      try {
         const res = await fetch(
           `/.netlify/functions/acceptInvite?token=${encodeURIComponent(token)}&noRedirect=1`,
           {
@@ -48,6 +47,5 @@ export default function AcceptInvite() {
     })();
   }, [token, nav]);
 
-  if (!token) return <div>Ongeldige link: token ontbreekt.</div>;
   return <div>{status}</div>;
 }


### PR DESCRIPTION
## Summary
- add Resend email helper and send invite metadata from the createInvite function
- update the admin invite form and members admin flow to toggle email delivery and surface status
- ensure the accept invite page redirects unauthenticated users to login and document new environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea20cde7c833282a6c6db7c112493