### PR TITLE
Enable invite acceptance without requiring login

### DIFF
--- a/netlify/functions/_shared/supabaseServer.ts
+++ b/netlify/functions/_shared/supabaseServer.ts
@@ -24,3 +24,10 @@ export function supabaseForRequest(authHeader?: string): SupabaseClient {
     global: { headers: authHeader ? { Authorization: authHeader } : {} },
   });
 }
+
+export function supabaseAdmin(): SupabaseClient {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY env vars');
+  return createClient(url, key, { auth: { persistSession: false } });
+}

--- a/netlify/functions/acceptInvite.ts
+++ b/netlify/functions/acceptInvite.ts
@@ -1,82 +1,259 @@
 import type { Handler } from '@netlify/functions';
-import { supabaseForRequest, buildCorsHeaders } from './_shared/supabaseServer';
+import { buildCorsHeaders, supabaseAdmin } from './_shared/supabaseServer';
+
+type InviteRow = {
+  id: string;
+  org_id: string;
+  email: string;
+  role: string;
+  token: string;
+  accepted_at?: string | null;
+  used_at?: string | null;
+  expires_at?: string | null;
+  [key: string]: unknown;
+};
+
+type SupabaseAdminClient = ReturnType<typeof supabaseAdmin>;
+type MinimalUser = { id: string; email?: string | null };
+
+async function getAuthUserByEmail(admin: SupabaseAdminClient, email: string): Promise<MinimalUser | null> {
+  const normalized = email.trim().toLowerCase();
+  const { data, error } = await admin
+    .schema('auth')
+    .from('users')
+    .select('id,email')
+    .eq('email', normalized)
+    .limit(1)
+    .maybeSingle();
+
+  if (error && error.code !== 'PGRST116') {
+    throw new Error(error.message);
+  }
+
+  if (!data) return null;
+
+  return { id: data.id, email: data.email } as MinimalUser;
+}
+
+async function ensureAuthUser(admin: SupabaseAdminClient, email: string): Promise<MinimalUser> {
+  const normalized = email.trim().toLowerCase();
+  const existing = await getAuthUserByEmail(admin, normalized);
+  if (existing) {
+    return existing;
+  }
+
+  const { data, error } = await admin.auth.admin.createUser({
+    email: normalized,
+    email_confirm: false,
+  });
+
+  if (error) {
+    if (error.message?.toLowerCase().includes('already registered')) {
+      const retry = await getAuthUserByEmail(admin, normalized);
+      if (retry) return retry;
+    }
+    throw new Error(error.message || 'Kon gebruiker niet aanmaken');
+  }
+
+  if (!data?.user) {
+    throw new Error('Gebruiker niet aangemaakt');
+  }
+
+  return { id: data.user.id, email: data.user.email };
+}
+
+function buildRedirectLocation(event: Parameters<Handler>[0]) {
+  const scheme = (event.headers['x-forwarded-proto'] || 'https') as string;
+  const hostHeader = (event.headers['x-forwarded-host'] || event.headers.host) as
+    | string
+    | undefined;
+  const base =
+    process.env.APP_ORIGIN || (hostHeader ? `${scheme}://${hostHeader}` : `${scheme}://localhost`);
+  return `${base}/app?invite=accepted`;
+}
 
 export const handler: Handler = async (event) => {
   const headers = buildCorsHeaders(event.headers.origin);
   const jsonHeaders = { ...headers, 'Content-Type': 'application/json' };
 
-  if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 200, headers };
-  }
-
-  if (event.httpMethod !== 'GET') {
-    return {
-      statusCode: 405,
-      headers: jsonHeaders,
-      body: JSON.stringify({ error: 'Use GET' }),
-    };
-  }
-
-  const auth = event.headers.authorization;
-  if (!auth) {
-    return {
-      statusCode: 401,
-      headers: jsonHeaders,
-      body: JSON.stringify({ error: 'Missing Authorization header' }),
-    };
-  }
-
-  const token = event.queryStringParameters?.token;
-  const noRedirect = event.queryStringParameters?.noRedirect === '1';
-  if (!token) {
-    return {
-      statusCode: 400,
-      headers: jsonHeaders,
-      body: JSON.stringify({ error: 'Missing token' }),
-    };
-  }
-
   try {
-    const supabase = supabaseForRequest(auth);
-    const { data: me, error: meErr } = await supabase.auth.getUser();
-    if (meErr || !me?.user) {
+    if (event.httpMethod === 'OPTIONS') {
+      return { statusCode: 200, headers };
+    }
+
+    if (event.httpMethod !== 'GET') {
       return {
-        statusCode: 401,
+        statusCode: 405,
         headers: jsonHeaders,
-        body: JSON.stringify({ error: 'Not authenticated' }),
+        body: JSON.stringify({ error: 'Use GET' }),
       };
     }
 
-    const { error: accErr } = await supabase.rpc('accept_invite', { p_token: token } as any);
-    if (accErr) {
+    const token = event.queryStringParameters?.token;
+    const noRedirect = event.queryStringParameters?.noRedirect === '1';
+
+    if (!token) {
       return {
         statusCode: 400,
         headers: jsonHeaders,
-        body: JSON.stringify({ error: accErr.message }),
+        body: JSON.stringify({ error: 'Ontbrekende token parameter' }),
       };
     }
+
+    const admin = supabaseAdmin();
+
+    const { data: invite, error: inviteErr } = await admin
+      .from('invites')
+      .select('*')
+      .eq('token', token)
+      .limit(1)
+      .maybeSingle();
+
+    if (inviteErr) {
+      return {
+        statusCode: 400,
+        headers: jsonHeaders,
+        body: JSON.stringify({ error: inviteErr.message }),
+      };
+    }
+
+    if (!invite) {
+      return {
+        statusCode: 400,
+        headers: jsonHeaders,
+        body: JSON.stringify({ error: 'Uitnodiging niet gevonden of ongeldig' }),
+      };
+    }
+
+    const inviteRow = invite as InviteRow;
+    const hasAcceptedAt = Object.prototype.hasOwnProperty.call(inviteRow, 'accepted_at');
+    const hasUsedAt = Object.prototype.hasOwnProperty.call(inviteRow, 'used_at');
+    const usageField: 'accepted_at' | 'used_at' | null = hasAcceptedAt
+      ? 'accepted_at'
+      : hasUsedAt
+        ? 'used_at'
+        : null;
+    const alreadyUsedValue = usageField ? (inviteRow as any)[usageField] : null;
+
+    if (alreadyUsedValue) {
+      return {
+        statusCode: 409,
+        headers: jsonHeaders,
+        body: JSON.stringify({ error: 'Uitnodiging is al gebruikt' }),
+      };
+    }
+
+    const expiresAtValue = Object.prototype.hasOwnProperty.call(inviteRow, 'expires_at')
+      ? inviteRow.expires_at
+      : null;
+    const expiresAt = expiresAtValue ? new Date(expiresAtValue as string) : null;
+    if (expiresAt && Number.isFinite(expiresAt.getTime()) && expiresAt.getTime() < Date.now()) {
+      return {
+        statusCode: 410,
+        headers: jsonHeaders,
+        body: JSON.stringify({ error: 'Uitnodiging is verlopen' }),
+      };
+    }
+
+    const user = await ensureAuthUser(admin, inviteRow.email);
+
+    const { error: membershipErr } = await admin
+      .from('memberships')
+      .upsert(
+        { org_id: inviteRow.org_id, user_id: user.id, role: inviteRow.role },
+        { onConflict: 'org_id,user_id' }
+      );
+
+    if (membershipErr) {
+      return {
+        statusCode: 500,
+        headers: jsonHeaders,
+        body: JSON.stringify({ error: membershipErr.message }),
+      };
+    }
+
+    const timestamp = new Date().toISOString();
+    let markedUsed = false;
+
+    if (usageField) {
+      let updateQuery = admin
+        .from('invites')
+        .update({ [usageField]: timestamp })
+        .eq('id', inviteRow.id)
+        .is(usageField, null);
+
+      const { data: updateRows, error: updateErr } = await updateQuery.select('id');
+
+      if (updateErr) {
+        return {
+          statusCode: 500,
+          headers: jsonHeaders,
+          body: JSON.stringify({ error: updateErr.message }),
+        };
+      }
+
+      if (!updateRows || updateRows.length === 0) {
+        return {
+          statusCode: 409,
+          headers: jsonHeaders,
+          body: JSON.stringify({ error: 'Uitnodiging is al gebruikt' }),
+        };
+      }
+
+      markedUsed = true;
+    } else {
+      const { data: deletedRows, error: deleteErr } = await admin
+        .from('invites')
+        .delete()
+        .eq('id', inviteRow.id)
+        .select('id');
+
+      if (deleteErr) {
+        return {
+          statusCode: 500,
+          headers: jsonHeaders,
+          body: JSON.stringify({ error: deleteErr.message }),
+        };
+      }
+
+      if (!deletedRows || deletedRows.length === 0) {
+        return {
+          statusCode: 409,
+          headers: jsonHeaders,
+          body: JSON.stringify({ error: 'Uitnodiging is al gebruikt' }),
+        };
+      }
+
+      markedUsed = true;
+    }
+
+    if (!markedUsed) {
+      return {
+        statusCode: 500,
+        headers: jsonHeaders,
+        body: JSON.stringify({ error: 'Kon uitnodiging niet afronden' }),
+      };
+    }
+
+    const redirectTo = buildRedirectLocation(event);
 
     if (noRedirect) {
       return {
         statusCode: 200,
         headers: jsonHeaders,
-        body: JSON.stringify({ success: true }),
+        body: JSON.stringify({ success: true, redirectTo }),
       };
     }
 
-    const scheme = (event.headers['x-forwarded-proto'] || 'https') as string;
-    const hostHeader =
-      (event.headers['x-forwarded-host'] || event.headers.host) as string | undefined;
-    const base = process.env.APP_ORIGIN || (hostHeader ? `${scheme}://${hostHeader}` : `${scheme}://localhost`);
     return {
       statusCode: 302,
-      headers: { ...headers, Location: `${base}/app?accepted=1` },
+      headers: { ...headers, Location: redirectTo },
     };
-  } catch (e: any) {
+  } catch (error: any) {
     return {
       statusCode: 500,
       headers: jsonHeaders,
-      body: JSON.stringify({ error: e?.message || 'acceptInvite failure' }),
+      body: JSON.stringify({ error: error?.message || 'acceptInvite failure' }),
     };
   }
 };

--- a/netlify/functions/createInvite.ts
+++ b/netlify/functions/createInvite.ts
@@ -142,10 +142,10 @@ export const handler: Handler = async (event) => {
 
     const sendEmail = (json as any).sendEmail !== false;
 
-    const mail: { attempted: boolean; sent: boolean; reason?: string } = {
+    const mail: { attempted: boolean; sent: boolean; reason: string | null } = {
       attempted: false,
       sent: false,
-      reason: undefined,
+      reason: null,
     };
 
     if (sendEmail) {
@@ -159,6 +159,8 @@ export const handler: Handler = async (event) => {
       if (!r.sent) {
         mail.reason = r.reason ?? 'unknown';
       }
+    } else {
+      mail.reason = 'disabled';
     }
 
     return {

--- a/src/components/AdminInviteForm.jsx
+++ b/src/components/AdminInviteForm.jsx
@@ -79,16 +79,10 @@ export default function AdminInviteForm({
       const acceptUrl = typeof body?.acceptUrl === 'string' ? body.acceptUrl : '';
       setCopyLink(acceptUrl);
       const emailInfo = body?.email && typeof body.email === 'object' ? body.email : null;
-      if (emailInfo?.attempted) {
-        setMessage(
-          emailInfo.sent
-            ? 'Mail verstuurd.'
-            : 'Link gekopieerd (email niet verstuurd).'
-        );
-      } else if (shouldSendEmail) {
-        setMessage('Link gekopieerd (email niet verstuurd).');
+      if (emailInfo?.attempted && emailInfo.sent) {
+        setMessage('E-mail verstuurd');
       } else {
-        setMessage('E-mail overslagen, link gekopieerd.');
+        setMessage('E-mail niet verstuurd, link gekopieerd');
       }
       setEmail('');
       setRole('CUSTOMER');


### PR DESCRIPTION
## Summary
- add a reusable Supabase service-role client helper for Netlify functions
- refactor the acceptInvite function to work without a JWT by using the service-role client, auto-creating users, upserting memberships, and handling invite lifecycle
- tweak invite creation to report email send status and update the admin UI/accept page messaging for the email flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceb3a149b0833295249c5654990589