### PR TITLE
fix: TS config + acceptInvite uses auth.users lookup; add Netlify types fallback

### DIFF
--- a/netlify/functions/acceptInvite.ts
+++ b/netlify/functions/acceptInvite.ts
@@ -1,256 +1,149 @@
-import type { Handler } from '@netlify/functions';
-import { buildCorsHeaders, supabaseAdmin } from './_shared/supabaseServer';
+import type { Handler } from '@netlify/functions'
+import { buildCorsHeaders, supabaseAdmin } from './_shared/supabaseServer'
 
 type InviteRow = {
-  id: string;
-  org_id: string;
-  email: string;
-  role: string;
-  token: string;
-  accepted_at?: string | null;
-  used_at?: string | null;
-  expires_at?: string | null;
-  [key: string]: unknown;
-};
-
-type SupabaseAdminClient = ReturnType<typeof supabaseAdmin>;
-type MinimalUser = { id: string; email?: string | null };
-
-async function getAuthUserByEmail(
-  admin: SupabaseAdminClient,
+  id: string
+  org_id: string
   email: string
-): Promise<MinimalUser | null> {
-  const normalized = email.trim().toLowerCase();
-  const { data, error } = await admin.auth.admin.getUserByEmail(normalized);
-
-  if (error && !error.message?.toLowerCase().includes('user not found')) {
-    throw new Error(error.message);
-  }
-
-  if (!data?.user) return null;
-
-  return { id: data.user.id, email: data.user.email };
+  role: string
+  token: string
+  accepted_at?: string | null
+  used_at?: string | null
+  expires_at?: string | null
 }
 
-async function ensureAuthUser(admin: SupabaseAdminClient, email: string): Promise<MinimalUser> {
-  const normalized = email.trim().toLowerCase();
-  const existing = await getAuthUserByEmail(admin, normalized);
-  if (existing) {
-    return existing;
-  }
+type SupabaseAdminClient = ReturnType<typeof supabaseAdmin>
+type MinimalUser = { id: string; email?: string | null }
 
-  const { data, error } = await admin.auth.admin.createUser({
-    email: normalized,
-    email_confirm: false,
-  });
+function json(status: number, headers: Record<string, string>, body: unknown) {
+  return { statusCode: status, headers: { ...headers, 'Content-Type': 'application/json' }, body: JSON.stringify(body) }
+}
 
-  if (error) {
-    if (error.message?.toLowerCase().includes('already registered')) {
-      const retry = await getAuthUserByEmail(admin, normalized);
-      if (retry) return retry;
-    }
-    throw new Error(error.message || 'Kon gebruiker niet aanmaken');
-  }
-
-  if (!data?.user) {
-    throw new Error('Gebruiker niet aangemaakt');
-  }
-
-  return { id: data.user.id, email: data.user.email };
+function redirect(headers: Record<string, string>, to: string) {
+  return { statusCode: 302, headers: { ...headers, Location: to } }
 }
 
 function buildRedirectLocation(event: Parameters<Handler>[0]) {
-  const scheme = (event.headers['x-forwarded-proto'] || 'https') as string;
-  const hostHeader = (event.headers['x-forwarded-host'] || event.headers.host) as
-    | string
-    | undefined;
-  const base =
-    process.env.APP_ORIGIN || (hostHeader ? `${scheme}://${hostHeader}` : `${scheme}://localhost`);
-  return `${base}/app?invite=accepted`;
+  const scheme = (event.headers['x-forwarded-proto'] || 'https') as string
+  const host = (event.headers['x-forwarded-host'] || event.headers.host) as string | undefined
+  const base = process.env.APP_ORIGIN || (host ? `${scheme}://${host}` : `${scheme}://localhost`)
+  return `${base}/app?invite=accepted`
+}
+
+/** Vind user via auth schema (er is geen SDK getUserByEmail) */
+async function findAuthUserByEmail(admin: SupabaseAdminClient, email: string): Promise<MinimalUser | null> {
+  const normalized = email.trim().toLowerCase()
+  const { data, error } = await admin
+    .schema('auth')
+    .from('users')
+    .select('id,email')
+    .eq('email', normalized)
+    .limit(1)
+    .maybeSingle()
+
+  if (error && error.code !== 'PGRST116') throw new Error(error.message)
+  if (!data) return null
+  return { id: (data as any).id, email: (data as any).email ?? normalized }
+}
+
+/** Bestaat user? -> return; anders aanmaken via service-role */
+async function ensureAuthUser(admin: SupabaseAdminClient, email: string): Promise<MinimalUser> {
+  const existing = await findAuthUserByEmail(admin, email)
+  if (existing) return existing
+
+  const { data, error } = await admin.auth.admin.createUser({
+    email: email.trim().toLowerCase(),
+    email_confirm: false
+  })
+  if (error) {
+    // second try: race-condition?
+    const retry = await findAuthUserByEmail(admin, email)
+    if (retry) return retry
+    throw new Error(error.message || 'Kon gebruiker niet aanmaken')
+  }
+  if (!data?.user) throw new Error('Gebruiker niet aangemaakt')
+  return { id: data.user.id, email: data.user.email }
 }
 
 export const handler: Handler = async (event) => {
-  const headers = buildCorsHeaders(event.headers.origin);
-  const jsonHeaders = { ...headers, 'Content-Type': 'application/json' };
+  const headers = buildCorsHeaders(event.headers?.origin)
+  const j = (s: number, b: unknown) => json(s, headers, b)
 
   try {
-    if (event.httpMethod === 'OPTIONS') {
-      return { statusCode: 200, headers };
-    }
+    if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers }
+    if (event.httpMethod !== 'GET') return j(405, { error: 'Use GET' })
 
-    if (event.httpMethod !== 'GET') {
-      return {
-        statusCode: 405,
-        headers: jsonHeaders,
-        body: JSON.stringify({ error: 'Use GET' }),
-      };
-    }
+    const token = event.queryStringParameters?.token
+    const noRedirect = event.queryStringParameters?.noRedirect === '1'
+    if (!token) return j(400, { error: 'Ontbrekende token parameter' })
 
-    const token = event.queryStringParameters?.token;
-    const noRedirect = event.queryStringParameters?.noRedirect === '1';
+    const admin = supabaseAdmin()
 
-    if (!token) {
-      return {
-        statusCode: 400,
-        headers: jsonHeaders,
-        body: JSON.stringify({ error: 'Ontbrekende token parameter' }),
-      };
-    }
-
-    const admin = supabaseAdmin();
-
+    // 1) Vind invite
     const { data: invite, error: inviteErr } = await admin
       .from('invites')
       .select('*')
       .eq('token', token)
       .limit(1)
-      .maybeSingle();
+      .maybeSingle()
 
-    if (inviteErr) {
-      return {
-        statusCode: 400,
-        headers: jsonHeaders,
-        body: JSON.stringify({ error: inviteErr.message }),
-      };
+    if (inviteErr) return j(400, { error: inviteErr.message })
+    if (!invite) return j(400, { error: 'Uitnodiging niet gevonden of ongeldig' })
+
+    const inv = invite as InviteRow
+
+    // 2) Al gebruikt/verlopen?
+    const usageField = (Object.prototype.hasOwnProperty.call(inv, 'accepted_at') ? 'accepted_at'
+                      : Object.prototype.hasOwnProperty.call(inv, 'used_at') ? 'used_at'
+                      : null) as 'accepted_at' | 'used_at' | null
+
+    if (usageField && (inv as any)[usageField]) {
+      return j(409, { error: 'Uitnodiging is al gebruikt' })
+    }
+    if (inv.expires_at) {
+      const exp = new Date(inv.expires_at)
+      if (Number.isFinite(exp.getTime()) && exp.getTime() < Date.now()) {
+        return j(410, { error: 'Uitnodiging is verlopen' })
+      }
     }
 
-    if (!invite) {
-      return {
-        statusCode: 400,
-        headers: jsonHeaders,
-        body: JSON.stringify({ error: 'Uitnodiging niet gevonden of ongeldig' }),
-      };
-    }
+    // 3) User garanderen
+    const user = await ensureAuthUser(admin, inv.email)
 
-    const inviteRow = invite as InviteRow;
-    const hasAcceptedAt = Object.prototype.hasOwnProperty.call(inviteRow, 'accepted_at');
-    const hasUsedAt = Object.prototype.hasOwnProperty.call(inviteRow, 'used_at');
-    const usageField: 'accepted_at' | 'used_at' | null = hasAcceptedAt
-      ? 'accepted_at'
-      : hasUsedAt
-        ? 'used_at'
-        : null;
-    const alreadyUsedValue = usageField ? (inviteRow as any)[usageField] : null;
-
-    if (alreadyUsedValue) {
-      return {
-        statusCode: 409,
-        headers: jsonHeaders,
-        body: JSON.stringify({ error: 'Uitnodiging is al gebruikt' }),
-      };
-    }
-
-    const expiresAtValue = Object.prototype.hasOwnProperty.call(inviteRow, 'expires_at')
-      ? inviteRow.expires_at
-      : null;
-    const expiresAt = expiresAtValue ? new Date(expiresAtValue as string) : null;
-    if (expiresAt && Number.isFinite(expiresAt.getTime()) && expiresAt.getTime() < Date.now()) {
-      return {
-        statusCode: 410,
-        headers: jsonHeaders,
-        body: JSON.stringify({ error: 'Uitnodiging is verlopen' }),
-      };
-    }
-
-    const user = await ensureAuthUser(admin, inviteRow.email);
-
-    const { error: membershipErr } = await admin
+    // 4) Membership upsert
+    const { error: memErr } = await admin
       .from('memberships')
       .upsert(
-        { org_id: inviteRow.org_id, user_id: user.id, role: inviteRow.role },
+        { org_id: inv.org_id, user_id: user.id, role: inv.role },
         { onConflict: 'org_id,user_id' }
-      );
+      )
+    if (memErr) return j(500, { error: memErr.message })
 
-    if (membershipErr) {
-      return {
-        statusCode: 500,
-        headers: jsonHeaders,
-        body: JSON.stringify({ error: membershipErr.message }),
-      };
-    }
-
-    const timestamp = new Date().toISOString();
-    let markedUsed = false;
-
+    // 5) Token markeren (of verwijderen)
+    let ok = false
     if (usageField) {
-      let updateQuery = admin
+      const { data: upd, error: updErr } = await admin
         .from('invites')
-        .update({ [usageField]: timestamp })
-        .eq('id', inviteRow.id)
-        .is(usageField, null);
-
-      const { data: updateRows, error: updateErr } = await updateQuery.select('id');
-
-      if (updateErr) {
-        return {
-          statusCode: 500,
-          headers: jsonHeaders,
-          body: JSON.stringify({ error: updateErr.message }),
-        };
-      }
-
-      if (!updateRows || updateRows.length === 0) {
-        return {
-          statusCode: 409,
-          headers: jsonHeaders,
-          body: JSON.stringify({ error: 'Uitnodiging is al gebruikt' }),
-        };
-      }
-
-      markedUsed = true;
+        .update({ [usageField]: new Date().toISOString() })
+        .eq('id', inv.id)
+        .is(usageField, null)
+        .select('id')
+      if (updErr) return j(500, { error: updErr.message })
+      ok = !!upd && upd.length > 0
     } else {
-      const { data: deletedRows, error: deleteErr } = await admin
+      const { data: deld, error: delErr } = await admin
         .from('invites')
         .delete()
-        .eq('id', inviteRow.id)
-        .select('id');
-
-      if (deleteErr) {
-        return {
-          statusCode: 500,
-          headers: jsonHeaders,
-          body: JSON.stringify({ error: deleteErr.message }),
-        };
-      }
-
-      if (!deletedRows || deletedRows.length === 0) {
-        return {
-          statusCode: 409,
-          headers: jsonHeaders,
-          body: JSON.stringify({ error: 'Uitnodiging is al gebruikt' }),
-        };
-      }
-
-      markedUsed = true;
+        .eq('id', inv.id)
+        .select('id')
+      if (delErr) return j(500, { error: delErr.message })
+      ok = !!deld && deld.length > 0
     }
+    if (!ok) return j(409, { error: 'Uitnodiging is al gebruikt' })
 
-    if (!markedUsed) {
-      return {
-        statusCode: 500,
-        headers: jsonHeaders,
-        body: JSON.stringify({ error: 'Kon uitnodiging niet afronden' }),
-      };
-    }
-
-    const redirectTo = buildRedirectLocation(event);
-
-    if (noRedirect) {
-      return {
-        statusCode: 200,
-        headers: jsonHeaders,
-        body: JSON.stringify({ success: true, redirectTo }),
-      };
-    }
-
-    return {
-      statusCode: 302,
-      headers: { ...headers, Location: redirectTo },
-    };
-  } catch (error: any) {
-    return {
-      statusCode: 500,
-      headers: jsonHeaders,
-      body: JSON.stringify({ error: error?.message || 'acceptInvite failure' }),
-    };
+    const to = buildRedirectLocation(event)
+    return noRedirect ? j(200, { success: true, redirectTo: to }) : redirect(headers, to)
+  } catch (e: any) {
+    return j(500, { error: e?.message || 'acceptInvite failure' })
   }
-};
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "typescript": "^5.6.3",
+    "@types/node": "^22.7.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,12 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "Node",
+    "strict": true,
+    "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM"],
     "types": ["@netlify/functions"],
     "typeRoots": ["./types", "./node_modules/@types"]
   },

--- a/types/@netlify/functions/index.d.ts
+++ b/types/@netlify/functions/index.d.ts
@@ -1,29 +1,7 @@
-export interface HandlerEvent {
-  rawUrl: string;
-  rawQuery: string | null;
-  path: string;
-  httpMethod: string;
-  headers: Record<string, string | undefined>;
-  queryStringParameters?: Record<string, string | undefined> | null;
-  body?: string | null;
-  isBase64Encoded?: boolean;
+declare module '@netlify/functions' {
+  export type Handler = (event: any, context: any) => Promise<{
+    statusCode: number
+    headers?: Record<string, string>
+    body?: string
+  }>
 }
-
-export interface HandlerContext {
-  functionName: string;
-  clientContext?: unknown;
-  identity?: unknown;
-}
-
-export interface HandlerResponse {
-  statusCode: number;
-  headers?: Record<string, string | undefined>;
-  multiValueHeaders?: Record<string, string[]>;
-  body?: string;
-  isBase64Encoded?: boolean;
-}
-
-export type Handler = (
-  event: HandlerEvent,
-  context: HandlerContext
-) => Promise<HandlerResponse> | HandlerResponse;


### PR DESCRIPTION
## Summary
- align the TypeScript config with the required Netlify settings and strict compiler options
- add a fallback `@netlify/functions` handler type definition for editors without the dependency
- rewrite the `acceptInvite` Netlify function to resolve users via the `auth.users` table and support invite acceptance without login

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d03c1dd418833297ab24a86353727a