### PR TITLE
Add invite management actions

### DIFF
--- a/.codex/patches/001_getAccessToken.diff
+++ b/.codex/patches/001_getAccessToken.diff
@@ -1,0 +1,9 @@
+--- /dev/null	2025-09-22 08:58:43.334847071 +0000
++++ src/lib/getAccessToken.ts	2025-09-22 09:54:02.471811491 +0000
+@@ -0,0 +1,6 @@
++import { supabase } from './supabaseClient';
++
++export async function getAccessToken() {
++  const { data } = await supabase.auth.getSession();
++  return data.session?.access_token ?? null;
++}

--- a/.codex/patches/002_invitesApi.diff
+++ b/.codex/patches/002_invitesApi.diff
@@ -1,0 +1,81 @@
+--- /dev/null	2025-09-22 08:58:43.334847071 +0000
++++ src/lib/invitesApi.ts	2025-09-22 09:53:35.256339569 +0000
+@@ -0,0 +1,78 @@
++import { getAccessToken } from './getAccessToken';
++
++const BASE_URL = import.meta.env.VITE_APP_ORIGIN ?? window.location.origin;
++
++async function api(path: string, init: RequestInit = {}) {
++  const token = await getAccessToken();
++  const headers = new Headers(init.headers ?? {});
++
++  if (token) {
++    headers.set('Authorization', `Bearer ${token}`);
++  }
++
++  const shouldSetContentType = !!init.body && !headers.has('Content-Type');
++  if (shouldSetContentType) {
++    headers.set('Content-Type', 'application/json');
++  }
++
++  try {
++    const response = await fetch(`${BASE_URL}${path}`, { ...init, headers });
++
++    if (response.ok) {
++      return response;
++    }
++
++    const text = await response.text();
++    let message = 'Er ging iets mis. Probeer later opnieuw.';
++
++    if (text) {
++      try {
++        const data = JSON.parse(text) as { error?: unknown };
++        if (typeof data?.error === 'string' && data.error.trim()) {
++          message = data.error.trim();
++        } else if (
++          data &&
++          typeof data.error === 'object' &&
++          data.error !== null &&
++          'message' in (data.error as Record<string, unknown>)
++        ) {
++          const nested = (data.error as { message?: unknown }).message;
++          if (typeof nested === 'string' && nested.trim()) {
++            message = nested.trim();
++          }
++        } else if (text.trim()) {
++          message = text.trim();
++        }
++      } catch {
++        if (text.trim()) {
++          message = text.trim();
++        }
++      }
++    }
++
++    throw new Error(message);
++  } catch (error) {
++    if (error instanceof Error) {
++      throw error;
++    }
++    throw new Error('Er ging iets mis. Probeer later opnieuw.');
++  }
++}
++
++export async function resendInvite(orgId: string, email: string): Promise<{ token: string }> {
++  const response = await api('/.netlify/functions/invites-resend', {
++    method: 'POST',
++    headers: { 'Content-Type': 'application/json' },
++    body: JSON.stringify({ org_id: orgId, email }),
++  });
++
++  return response.json() as Promise<{ token: string }>;
++}
++
++export async function revokeInvite(token: string): Promise<void> {
++  await api('/.netlify/functions/invites-revoke', {
++    method: 'POST',
++    headers: { 'Content-Type': 'application/json' },
++    body: JSON.stringify({ token }),
++  });
++}

--- a/.codex/patches/003_membersadmin.diff
+++ b/.codex/patches/003_membersadmin.diff
@@ -1,0 +1,180 @@
+diff --git a/src/components/MembersAdmin.jsx b/src/components/MembersAdmin.jsx
+index 04e24c0..8462964 100644
+--- a/src/components/MembersAdmin.jsx
++++ b/src/components/MembersAdmin.jsx
+@@ -8,0 +9,2 @@ import { netlifyJson } from '../lib/netlifyFetch';
++import { supabase } from '../lib/supabaseClient';
++import { resendInvite, revokeInvite } from '../lib/invitesApi';
+@@ -17,0 +20,8 @@ function VisuallyHidden({ children }) {
++function formatDateTime(value){ if(!value) return null; const d=new Date(value); if(Number.isNaN(d.getTime())) return null; return d.toLocaleString('nl-NL',{dateStyle:'short',timeStyle:'short'}); }
++
++function isInviteOpen(invite){ if(!invite || invite.used_at || invite.revoked_at) return false; if(!invite.expires_at) return true; const expiresAt=new Date(invite.expires_at).getTime(); return Number.isNaN(expiresAt)?true:expiresAt>Date.now(); }
++
++function normalizeInviteError(error){ const raw=typeof error?.message==='string'?error.message:''; if(raw && /limit/i.test(raw)) return 'Je hebt het limiet voor uitnodigingen bereikt. Probeer het later opnieuw.'; return raw || 'Er ging iets mis. Probeer later opnieuw.'; }
++
++function inviteKey(invite){ if(!invite) return ''; const token=invite.token ?? invite.id; if(token) return token; const email=invite.email ? String(invite.email).trim().toLowerCase() : ''; if(email) return email; return invite.created_at ?? ''; }
++
+@@ -78,0 +89,4 @@ export default function MembersAdmin() {
++  const [invites, setInvites] = useState([]);
++  const [invitesLoading, setInvitesLoading] = useState(false);
++  const [invitesError, setInvitesError] = useState('');
++  const [busyInvite, setBusyInvite] = useState(null);
+@@ -111,0 +126,28 @@ export default function MembersAdmin() {
++  async function fetchInvites() {
++    if (!activeOrgId || role !== 'ADMIN') {
++      setInvites([]);
++      setInvitesError('');
++      return;
++    }
++    setInvitesLoading(true);
++    setInvitesError('');
++    try {
++      const { data, error } = await supabase
++        .from('invites')
++        .select('id,org_id,email,role,token,created_at,expires_at,used_at,revoked_at')
++        .eq('org_id', activeOrgId)
++        .order('created_at', { ascending: false });
++      if (error) {
++        throw error;
++      }
++      setInvites(Array.isArray(data) ? data : []);
++    } catch (error) {
++      console.warn('[MembersAdmin] listInvites failed', { org: activeOrgId, error });
++      setInvitesError(error?.message || 'Onbekende fout');
++      setInvites([]);
++    } finally {
++      setInvitesLoading(false);
++    }
++  }
++  useEffect(()=>{ fetchInvites(); /* eslint-disable-next-line */ },[activeOrgId, role]);
++
+@@ -168,0 +211,46 @@ export default function MembersAdmin() {
++  async function handleResend(invite) {
++    const email = invite?.email ? String(invite.email).trim().toLowerCase() : '';
++    if (!email) {
++      setInvitesError('Geen e-mailadres beschikbaar voor deze invite.');
++      return;
++    }
++    if (!activeOrgId) {
++      setInvitesError('Geen organisatie beschikbaar.');
++      return;
++    }
++    const busyKey = inviteKey(invite) || email;
++    setInvitesError('');
++    setBusyInvite({ token: busyKey, action: 'resend' });
++    try {
++      await resendInvite(activeOrgId, email);
++      setToast('Nieuwe invite verstuurd. Link 7 dagen geldig.');
++      await fetchInvites();
++    } catch (error) {
++      console.warn('[MembersAdmin] resendInvite failed', { org: activeOrgId, email, error });
++      setInvitesError(normalizeInviteError(error));
++    } finally {
++      setBusyInvite(null);
++    }
++  }
++
++  async function handleRevoke(invite) {
++    const token = invite?.token;
++    if (!token) {
++      setInvitesError('Geen invite token gevonden.');
++      return;
++    }
++    setInvitesError('');
++    const busyKey = inviteKey(invite) || token;
++    setBusyInvite({ token: busyKey, action: 'revoke' });
++    try {
++      await revokeInvite(token);
++      setToast('Invite ongeldig gemaakt.');
++      await fetchInvites();
++    } catch (error) {
++      console.warn('[MembersAdmin] revokeInvite failed', { token, error });
++      setInvitesError(normalizeInviteError(error));
++    } finally {
++      setBusyInvite(null);
++    }
++  }
++
+@@ -173,0 +262 @@ export default function MembersAdmin() {
++  const openInvites = useMemo(()=>invites.filter(isInviteOpen),[invites]);
+@@ -196,0 +286 @@ export default function MembersAdmin() {
++    fetchInvites();
+@@ -330,0 +421,78 @@ export default function MembersAdmin() {
++          <div className="overflow-hidden rounded-xl border border-[#eef1f6] bg-white shadow-sm">
++            <div className="border-b border-[#f2f4f8] px-4 py-2 text-xs font-medium text-[#81848b]">
++              Openstaande uitnodigingen
++            </div>
++            <div className="px-4 pt-3 text-[12px] text-[#6b7280]">Link 7 dagen geldig.</div>
++            {invitesError && (
++              <div className="px-4 pt-2 text-sm text-rose-700">Fout: {invitesError}</div>
++            )}
++            {invitesLoading ? (
++              <div className="px-4 py-6 text-sm text-[#6b7280]">Uitnodigingen laden…</div>
++            ) : openInvites.length === 0 ? (
++              <div className="px-4 py-6 text-sm text-[#6b7280]">Geen openstaande uitnodigingen.</div>
++            ) : (
++              <ul className="divide-y divide-[#f2f4f8] pt-2">
++                {openInvites.map((invite, index) => {
++                  const baseKey = inviteKey(invite);
++                  const emailKey = invite?.email ? String(invite.email).trim().toLowerCase() : '';
++                  const itemKey = baseKey || emailKey || invite?.created_at || `invite-${index}`;
++                  const isBusy = busyInvite?.token === itemKey;
++                  const busyAction = isBusy ? busyInvite?.action : null;
++                  const canResend = Boolean(invite?.email && activeOrgId);
++                  const canRevoke = Boolean(invite?.token);
++                  const expiresLabel = formatDateTime(invite?.expires_at);
++                  return (
++                    <li key={itemKey} className="flex flex-wrap items-center gap-3 px-4 py-3">
++                      <div className="min-w-0 flex-1">
++                        <div className="flex items-center gap-2">
++                          <span className="truncate text-[15px] font-medium text-[#1c2b49]" title={invite?.email ?? '—'}>
++                            {invite?.email ?? '—'}
++                          </span>
++                          {invite?.role && <RoleBadge role={invite.role} />}
++                        </div>
++                        <div className="text-[12px] text-[#6b7280]">
++                          {expiresLabel ? `Verloopt op ${expiresLabel}` : 'Vervaldatum onbekend'}
++                        </div>
++                      </div>
++                      <div className="flex flex-wrap items-center justify-end gap-2">
++                        <button
++                          type="button"
++                          onClick={() => handleResend(invite)}
++                          disabled={!canResend || isBusy}
++                          aria-busy={isBusy && busyAction === 'resend'}
++                          className="inline-flex h-9 items-center rounded-md border border-[#e5e7eb] px-3 text-sm text-[#1d4ed8] hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
++                          title={canResend ? undefined : 'Geen e-mailadres beschikbaar'}
++                        >
++                          {isBusy && busyAction === 'resend' ? (
++                            <svg className="h-[18px] w-[18px] animate-spin" viewBox="0 0 24 24">
++                              <circle cx="12" cy="12" r="10" stroke="#9aa0a6" strokeWidth="2" fill="none" />
++                              <path d="M22 12a10 10 0 0 1-10 10" stroke="#3b82f6" strokeWidth="2" fill="none" />
++                            </svg>
++                          ) : (
++                            'Opnieuw sturen'
++                          )}
++                        </button>
++                        <button
++                          type="button"
++                          onClick={() => handleRevoke(invite)}
++                          disabled={!canRevoke || isBusy}
++                          aria-busy={isBusy && busyAction === 'revoke'}
++                          className="inline-flex h-9 items-center rounded-md border border-[#e5e7eb] px-3 text-sm text-[#b91c1c] hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
++                        >
++                          {isBusy && busyAction === 'revoke' ? (
++                            <svg className="h-[18px] w-[18px] animate-spin" viewBox="0 0 24 24">
++                              <circle cx="12" cy="12" r="10" stroke="#fca5a5" strokeWidth="2" fill="none" />
++                              <path d="M22 12a10 10 0 0 1-10 10" stroke="#b91c1c" strokeWidth="2" fill="none" />
++                            </svg>
++                          ) : (
++                            'Ongeldig maken'
++                          )}
++                        </button>
++                      </div>
++                    </li>
++                  );
++                })}
++              </ul>
++            )}
++          </div>
++

--- a/src/components/MembersAdmin.jsx
+++ b/src/components/MembersAdmin.jsx
@@ -6,6 +6,8 @@ import RoleBadge from './RoleBadge';
 import AdminInviteForm from './AdminInviteForm';
 import { authHeader } from '../lib/authHeader';
 import { netlifyJson } from '../lib/netlifyFetch';
+import { supabase } from '../lib/supabaseClient';
+import { resendInvite, revokeInvite } from '../lib/invitesApi';
 
 const ROLES = ['ADMIN', 'TEAM', 'CUSTOMER'];
 const roleLabel = { ADMIN: 'Admin', TEAM: 'Team', CUSTOMER: 'Customer' };
@@ -14,6 +16,14 @@ function classNames(...xs) { return xs.filter(Boolean).join(' '); }
 function VisuallyHidden({ children }) {
   return <span style={{position:'absolute',left:-9999,top:'auto',width:1,height:1,overflow:'hidden'}}>{children}</span>;
 }
+
+function formatDateTime(value){ if(!value) return null; const d=new Date(value); if(Number.isNaN(d.getTime())) return null; return d.toLocaleString('nl-NL',{dateStyle:'short',timeStyle:'short'}); }
+
+function isInviteOpen(invite){ if(!invite || invite.used_at || invite.revoked_at) return false; if(!invite.expires_at) return true; const expiresAt=new Date(invite.expires_at).getTime(); return Number.isNaN(expiresAt)?true:expiresAt>Date.now(); }
+
+function normalizeInviteError(error){ const raw=typeof error?.message==='string'?error.message:''; if(raw && /limit/i.test(raw)) return 'Je hebt het limiet voor uitnodigingen bereikt. Probeer het later opnieuw.'; return raw || 'Er ging iets mis. Probeer later opnieuw.'; }
+
+function inviteKey(invite){ if(!invite) return ''; const token=invite.token ?? invite.id; if(token) return token; const email=invite.email ? String(invite.email).trim().toLowerCase() : ''; if(email) return email; return invite.created_at ?? ''; }
 
 // CSV helpers
 function csvEscape(v=''){const s=String(v??'');return /[",\n]/.test(s)?`"${s.replace(/"/g,'""')}"`:s;}
@@ -76,6 +86,10 @@ export default function MembersAdmin() {
   const [q, setQ] = useState('');
   const [toast, setToast] = useState('');
   const [confirm, setConfirm] = useState({ open: false, userId: null, email: '' });
+  const [invites, setInvites] = useState([]);
+  const [invitesLoading, setInvitesLoading] = useState(false);
+  const [invitesError, setInvitesError] = useState('');
+  const [busyInvite, setBusyInvite] = useState(null);
 
   async function fetchMembers() {
     if (!activeOrgId) return;
@@ -108,6 +122,34 @@ export default function MembersAdmin() {
     }
   }
   useEffect(()=>{ fetchMembers(); /* eslint-disable-next-line */ },[activeOrgId]);
+
+  async function fetchInvites() {
+    if (!activeOrgId || role !== 'ADMIN') {
+      setInvites([]);
+      setInvitesError('');
+      return;
+    }
+    setInvitesLoading(true);
+    setInvitesError('');
+    try {
+      const { data, error } = await supabase
+        .from('invites')
+        .select('id,org_id,email,role,token,created_at,expires_at,used_at,revoked_at')
+        .eq('org_id', activeOrgId)
+        .order('created_at', { ascending: false });
+      if (error) {
+        throw error;
+      }
+      setInvites(Array.isArray(data) ? data : []);
+    } catch (error) {
+      console.warn('[MembersAdmin] listInvites failed', { org: activeOrgId, error });
+      setInvitesError(error?.message || 'Onbekende fout');
+      setInvites([]);
+    } finally {
+      setInvitesLoading(false);
+    }
+  }
+  useEffect(()=>{ fetchInvites(); /* eslint-disable-next-line */ },[activeOrgId, role]);
 
   async function changeRole(userId, nextRole) {
     setBusyUser(userId);
@@ -166,11 +208,58 @@ export default function MembersAdmin() {
     }
   }
 
+  async function handleResend(invite) {
+    const email = invite?.email ? String(invite.email).trim().toLowerCase() : '';
+    if (!email) {
+      setInvitesError('Geen e-mailadres beschikbaar voor deze invite.');
+      return;
+    }
+    if (!activeOrgId) {
+      setInvitesError('Geen organisatie beschikbaar.');
+      return;
+    }
+    const busyKey = inviteKey(invite) || email;
+    setInvitesError('');
+    setBusyInvite({ token: busyKey, action: 'resend' });
+    try {
+      await resendInvite(activeOrgId, email);
+      setToast('Nieuwe invite verstuurd. Link 7 dagen geldig.');
+      await fetchInvites();
+    } catch (error) {
+      console.warn('[MembersAdmin] resendInvite failed', { org: activeOrgId, email, error });
+      setInvitesError(normalizeInviteError(error));
+    } finally {
+      setBusyInvite(null);
+    }
+  }
+
+  async function handleRevoke(invite) {
+    const token = invite?.token;
+    if (!token) {
+      setInvitesError('Geen invite token gevonden.');
+      return;
+    }
+    setInvitesError('');
+    const busyKey = inviteKey(invite) || token;
+    setBusyInvite({ token: busyKey, action: 'revoke' });
+    try {
+      await revokeInvite(token);
+      setToast('Invite ongeldig gemaakt.');
+      await fetchInvites();
+    } catch (error) {
+      console.warn('[MembersAdmin] revokeInvite failed', { token, error });
+      setInvitesError(normalizeInviteError(error));
+    } finally {
+      setBusyInvite(null);
+    }
+  }
+
   const filtered = useMemo(()=>{
     const s=q.trim().toLowerCase(); if(!s) return rows;
     return rows.filter(r => (r.email||'').toLowerCase().includes(s));
   },[rows,q]);
   const hasSearch = q.trim().length>0;
+  const openInvites = useMemo(()=>invites.filter(isInviteOpen),[invites]);
 
   function exportCsv(){
     const csv=rowsToCsv(filtered);
@@ -194,6 +283,7 @@ export default function MembersAdmin() {
     } else if (result.acceptUrl) {
       setToast('Invite link aangemaakt.');
     }
+    fetchInvites();
   }
 
   return (
@@ -320,6 +410,84 @@ export default function MembersAdmin() {
                             )}
                           </button>
                         ) : <span className="text-[11px] text-[#9aa0a6]">—</span>}
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-[#eef1f6] bg-white shadow-sm">
+            <div className="border-b border-[#f2f4f8] px-4 py-2 text-xs font-medium text-[#81848b]">
+              Openstaande uitnodigingen
+            </div>
+            <div className="px-4 pt-3 text-[12px] text-[#6b7280]">Link 7 dagen geldig.</div>
+            {invitesError && (
+              <div className="px-4 pt-2 text-sm text-rose-700">Fout: {invitesError}</div>
+            )}
+            {invitesLoading ? (
+              <div className="px-4 py-6 text-sm text-[#6b7280]">Uitnodigingen laden…</div>
+            ) : openInvites.length === 0 ? (
+              <div className="px-4 py-6 text-sm text-[#6b7280]">Geen openstaande uitnodigingen.</div>
+            ) : (
+              <ul className="divide-y divide-[#f2f4f8] pt-2">
+                {openInvites.map((invite, index) => {
+                  const baseKey = inviteKey(invite);
+                  const emailKey = invite?.email ? String(invite.email).trim().toLowerCase() : '';
+                  const itemKey = baseKey || emailKey || invite?.created_at || `invite-${index}`;
+                  const isBusy = busyInvite?.token === itemKey;
+                  const busyAction = isBusy ? busyInvite?.action : null;
+                  const canResend = Boolean(invite?.email && activeOrgId);
+                  const canRevoke = Boolean(invite?.token);
+                  const expiresLabel = formatDateTime(invite?.expires_at);
+                  return (
+                    <li key={itemKey} className="flex flex-wrap items-center gap-3 px-4 py-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="truncate text-[15px] font-medium text-[#1c2b49]" title={invite?.email ?? '—'}>
+                            {invite?.email ?? '—'}
+                          </span>
+                          {invite?.role && <RoleBadge role={invite.role} />}
+                        </div>
+                        <div className="text-[12px] text-[#6b7280]">
+                          {expiresLabel ? `Verloopt op ${expiresLabel}` : 'Vervaldatum onbekend'}
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap items-center justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => handleResend(invite)}
+                          disabled={!canResend || isBusy}
+                          aria-busy={isBusy && busyAction === 'resend'}
+                          className="inline-flex h-9 items-center rounded-md border border-[#e5e7eb] px-3 text-sm text-[#1d4ed8] hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                          title={canResend ? undefined : 'Geen e-mailadres beschikbaar'}
+                        >
+                          {isBusy && busyAction === 'resend' ? (
+                            <svg className="h-[18px] w-[18px] animate-spin" viewBox="0 0 24 24">
+                              <circle cx="12" cy="12" r="10" stroke="#9aa0a6" strokeWidth="2" fill="none" />
+                              <path d="M22 12a10 10 0 0 1-10 10" stroke="#3b82f6" strokeWidth="2" fill="none" />
+                            </svg>
+                          ) : (
+                            'Opnieuw sturen'
+                          )}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleRevoke(invite)}
+                          disabled={!canRevoke || isBusy}
+                          aria-busy={isBusy && busyAction === 'revoke'}
+                          className="inline-flex h-9 items-center rounded-md border border-[#e5e7eb] px-3 text-sm text-[#b91c1c] hover:bg-rose-50 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {isBusy && busyAction === 'revoke' ? (
+                            <svg className="h-[18px] w-[18px] animate-spin" viewBox="0 0 24 24">
+                              <circle cx="12" cy="12" r="10" stroke="#fca5a5" strokeWidth="2" fill="none" />
+                              <path d="M22 12a10 10 0 0 1-10 10" stroke="#b91c1c" strokeWidth="2" fill="none" />
+                            </svg>
+                          ) : (
+                            'Ongeldig maken'
+                          )}
+                        </button>
                       </div>
                     </li>
                   );

--- a/src/lib/getAccessToken.ts
+++ b/src/lib/getAccessToken.ts
@@ -1,0 +1,6 @@
+import { supabase } from './supabaseClient';
+
+export async function getAccessToken() {
+  const { data } = await supabase.auth.getSession();
+  return data.session?.access_token ?? null;
+}

--- a/src/lib/invitesApi.ts
+++ b/src/lib/invitesApi.ts
@@ -1,0 +1,78 @@
+import { getAccessToken } from './getAccessToken';
+
+const BASE_URL = import.meta.env.VITE_APP_ORIGIN ?? window.location.origin;
+
+async function api(path: string, init: RequestInit = {}) {
+  const token = await getAccessToken();
+  const headers = new Headers(init.headers ?? {});
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const shouldSetContentType = !!init.body && !headers.has('Content-Type');
+  if (shouldSetContentType) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  try {
+    const response = await fetch(`${BASE_URL}${path}`, { ...init, headers });
+
+    if (response.ok) {
+      return response;
+    }
+
+    const text = await response.text();
+    let message = 'Er ging iets mis. Probeer later opnieuw.';
+
+    if (text) {
+      try {
+        const data = JSON.parse(text) as { error?: unknown };
+        if (typeof data?.error === 'string' && data.error.trim()) {
+          message = data.error.trim();
+        } else if (
+          data &&
+          typeof data.error === 'object' &&
+          data.error !== null &&
+          'message' in (data.error as Record<string, unknown>)
+        ) {
+          const nested = (data.error as { message?: unknown }).message;
+          if (typeof nested === 'string' && nested.trim()) {
+            message = nested.trim();
+          }
+        } else if (text.trim()) {
+          message = text.trim();
+        }
+      } catch {
+        if (text.trim()) {
+          message = text.trim();
+        }
+      }
+    }
+
+    throw new Error(message);
+  } catch (error) {
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new Error('Er ging iets mis. Probeer later opnieuw.');
+  }
+}
+
+export async function resendInvite(orgId: string, email: string): Promise<{ token: string }> {
+  const response = await api('/.netlify/functions/invites-resend', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ org_id: orgId, email }),
+  });
+
+  return response.json() as Promise<{ token: string }>;
+}
+
+export async function revokeInvite(token: string): Promise<void> {
+  await api('/.netlify/functions/invites-revoke', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token }),
+  });
+}


### PR DESCRIPTION
## Summary
- add a helper to retrieve the current Supabase access token for authenticated requests
- create an invites API client to resend or revoke invites with consistent error handling
- extend the members admin view to list open invites and wire up resend/revoke actions with status feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d11966c7808332822618c13be90d7f