### PR TITLE
Preserve invite redirect through login

### DIFF
--- a/src/lib/resolveNextPath.js
+++ b/src/lib/resolveNextPath.js
@@ -1,0 +1,15 @@
+export const DEFAULT_AFTER_LOGIN = '/app/members';
+
+export function resolveNextPath(raw) {
+  if (!raw) return null;
+  let decoded = raw;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    decoded = raw;
+  }
+  if (!decoded.startsWith('/')) {
+    return null;
+  }
+  return decoded;
+}

--- a/src/pages/AuthCallback.jsx
+++ b/src/pages/AuthCallback.jsx
@@ -1,6 +1,7 @@
 // src/pages/AuthCallback.jsx
 import { useEffect } from 'react';
 import { supabase } from '../lib/supabaseClient';
+import { DEFAULT_AFTER_LOGIN, resolveNextPath } from '../lib/resolveNextPath';
 
 export default function AuthCallback() {
   useEffect(() => {
@@ -9,27 +10,29 @@ export default function AuthCallback() {
         const url = new URL(window.location.href);
         const hasCode = url.searchParams.get('code');
         const hash = url.hash;
+        const nextParam = url.searchParams.get('next');
+        const nextPath = resolveNextPath(nextParam) ?? DEFAULT_AFTER_LOGIN;
 
         // 1) OAuth PKCE: code → sessie
         if (hasCode) {
           const { error } = await supabase.auth.exchangeCodeForSession(window.location.href);
           if (error) console.error('exchangeCode error', error);
-          window.location.replace('/app');
+          window.location.replace(nextPath);
           return;
         }
 
         // 2) Magic-link (hash tokens): geef Supabase heel even
         if (hash && hash.includes('access_token=')) {
           await new Promise((r) => setTimeout(r, 50));
-          window.location.replace('/app');
+          window.location.replace(nextPath);
           return;
         }
 
         // 3) Fallback
-        window.location.replace('/app');
+        window.location.replace(nextPath);
       } catch (e) {
         console.error('AuthCallback error', e);
-        window.location.replace('/app');
+        window.location.replace(DEFAULT_AFTER_LOGIN);
       }
     })();
   }, []);

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,54 +1,64 @@
 // src/pages/Login.jsx
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabaseClient';
 import { useAuth } from '../providers/AuthProvider';
+import { DEFAULT_AFTER_LOGIN, resolveNextPath } from '../lib/resolveNextPath';
 
 export default function Login() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { user } = useAuth(); // alleen lezen
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [err, setErr] = useState('');
   const [didRedirect, setDidRedirect] = useState(false); // voorkom knipper/loop
 
+  const rawNext = useMemo(() => {
+    const params = new URLSearchParams(location.search);
+    return params.get('next');
+  }, [location.search]);
+  const nextPath = useMemo(() => resolveNextPath(rawNext), [rawNext]);
+
   // Eén debounced effect voor alle login-redirects
   useEffect(() => {
     if (didRedirect) return;
 
-    const url = new URL(window.location.href);
-    const hasHashTokens = window.location.hash.includes('access_token=');
-    const hasCode = url.searchParams.has('code');
-    const intent = url.searchParams.get('intent') === '1';
+    const params = new URLSearchParams(location.search);
+    const hasHashTokens = location.hash.includes('access_token=');
+    const hasCode = params.has('code');
+    const intent = params.get('intent') === '1';
+    const hasNext = Boolean(nextPath);
 
     // 1) Magic link / OAuth tokens? -> door naar /auth/callback
     if (hasHashTokens || hasCode) {
       setDidRedirect(true);
-      navigate('/auth/callback' + window.location.search + window.location.hash, { replace: true });
+      navigate(`/auth/callback${location.search}${location.hash}`, { replace: true });
       return;
     }
 
-    // 2) Al ingelogd? -> naar /app
+    // 2) Al ingelogd? -> naar next of ledenoverzicht
     if (user) {
       setDidRedirect(true);
-      navigate('/app', { replace: true });
+      navigate(nextPath ?? DEFAULT_AFTER_LOGIN, { replace: true });
       return;
     }
 
     // 3) Geen intent en geen tokens? -> per ongeluk op /login => terug naar /app
-    if (!intent) {
+    if (!intent && !hasNext) {
       setDidRedirect(true);
       navigate('/app', { replace: true });
       return;
     }
-  }, [user, navigate, didRedirect]);
+  }, [user, navigate, didRedirect, location.search, location.hash, nextPath]);
 
   const onSendLink = async (e) => {
     e.preventDefault();
     setErr('');
     setSent(false);
 
-    const redirectTo = `${window.location.origin}/auth/callback`;
+    const callbackSearch = nextPath ? `?next=${encodeURIComponent(nextPath)}` : '';
+    const redirectTo = `${window.location.origin}/auth/callback${callbackSearch}`;
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {


### PR DESCRIPTION
## Summary
- keep the invite token in the AcceptInvite flow and surface improved guidance when login is required or fails for a signed-in user
- honour the `next` query parameter during login and in the Supabase callback so successful auth returns to the invite page before redirecting to members
- add a shared helper for decoding validated `next` targets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d139c31ea48332bb9ec4059a039fe5