### PR TITLE
feat(members): protect MembersAdmin behind admin gate and redirect invites to /app

### DIFF
--- a/src/components/BluelineChatpilot.jsx
+++ b/src/components/BluelineChatpilot.jsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+import { NavLink, Navigate, useLocation, useNavigate } from 'react-router-dom';
 
 import { getAnonId } from "../utils/anonId";
 import { fetchRecentChats, saveRecentChat, deleteRecentChat } from "../utils/recentChats";
 import { appendToThread, getThread, deleteThread } from "../utils/threadStore";
 
 import AuthProfileButton from './AuthProfileButton';
+import PermissionGate from './PermissionGate';
 import MembersAdmin from './MembersAdmin';
 import SidebarNewsFeed from "./SidebarNewsFeed";
 
@@ -284,21 +285,23 @@ function AppSidebar({ open, onToggleSidebar, onToggleFeed, feedOpen, onNewChat, 
           </div>
 
           {/* --- Ledenbeheer (icoon/label, werkt ook ingeklapt) --- */}
-          <NavLink
-            to="/members"
-            title="Ledenbeheer"
-            className={({ isActive }) => [
-              "group flex items-center gap-3 rounded-xl px-3 py-2 transition-colors",
-              expanded ? "justify-start" : "justify-center",
-              isActive ? "bg-[#e8efff] text-[#194297]" : "text-[#66676b] hover:bg-[#f3f6ff] hover:text-[#194297]"
-            ].join(' ')}
-          >
-            {/* people/users icon */}
-            <svg width="20" height="20" viewBox="0 0 24 24" className="shrink-0">
-              <path fill="currentColor" d="M16 13a4 4 0 1 0-4-4a4 4 0 0 0 4 4m-8 0a3 3 0 1 0-3-3a3 3 0 0 0 3 3m8 2c-2.67 0-8 1.34-8 4v 2h16v-2c0-2.66-5.33-4-8-4m-8-1c-3 0-9 1.5-9 4v2h6v-2c0-1.35.74-2.5 1.93-3.41A11.5 11.5 0 0 0 0 18h0" />
-            </svg>
-            {expanded && <span className="text-[14px] font-medium">Ledenbeheer</span>}
-          </NavLink>
+          <PermissionGate perm="org:admin">
+            <NavLink
+              to="/members"
+              title="Ledenbeheer"
+              className={({ isActive }) => [
+                "group flex items-center gap-3 rounded-xl px-3 py-2 transition-colors",
+                expanded ? "justify-start" : "justify-center",
+                isActive ? "bg-[#e8efff] text-[#194297]" : "text-[#66676b] hover:bg-[#f3f6ff] hover:text-[#194297]"
+              ].join(' ')}
+            >
+              {/* people/users icon */}
+              <svg width="20" height="20" viewBox="0 0 24 24" className="shrink-0">
+                <path fill="currentColor" d="M16 13a4 4 0 1 0-4-4a4 4 0 0 0 4 4m-8 0a3 3 0 1 0-3-3a3 3 0 0 0 3 3m8 2c-2.67 0-8 1.34-8 4v 2h16v-2c0-2.66-5.33-4-8-4m-8-1c-3 0-9 1.5-9 4v2h6v-2c0-1.35.74-2.5 1.93-3.41A11.5 11.5 0 0 0 0 18h0" />
+              </svg>
+              {expanded && <span className="text-[14px] font-medium">Ledenbeheer</span>}
+            </NavLink>
+          </PermissionGate>
 
           {/* Newsfeed bij uitgeklapt */}
           {feedOpen && expanded && (
@@ -691,7 +694,12 @@ function goToChatRoute() {
             {isMembers ? (
               // ===== /members: MembersAdmin binnen de layout, gecentreerd (max-w-960) =====
               <div className="py-5">
-                <MembersAdmin />
+                <PermissionGate
+                  perm="org:admin"
+                  fallback={<Navigate to="/app" replace />}
+                >
+                  <MembersAdmin />
+                </PermissionGate>
               </div>
             ) : (
               // ===== Andere routes: Chat gecentreerd (max-w-760) =====

--- a/src/pages/AcceptInvite.jsx
+++ b/src/pages/AcceptInvite.jsx
@@ -44,7 +44,7 @@ export default function AcceptInvite() {
       // 200 => succes, 409 => al gebruikt (behandel als soft success)
       if (res.status === 200) {
         const data = await res.json().catch(() => ({}));
-        const to = typeof data?.redirectTo === 'string' ? data.redirectTo : '/app/members';
+        const to = typeof data?.redirectTo === 'string' ? data.redirectTo : '/app';
         setStatus('Uitnodiging geaccepteerd. Doorgaan…');
         sessionStorage.removeItem('pendingInviteToken');
         window.location.assign(to);
@@ -54,7 +54,7 @@ export default function AcceptInvite() {
       if (res.status === 409) {
         setStatus('Uitnodiging was al gebruikt. Doorgaan…');
         sessionStorage.removeItem('pendingInviteToken');
-        setTimeout(() => window.location.assign('/app/members'), 300);
+        setTimeout(() => window.location.assign('/app'), 300);
         return;
       }
 


### PR DESCRIPTION
## Summary
- wrap the members navigation link in an org admin permission gate so only admins see it
- guard the MembersAdmin route itself with the same gate and redirect non-admins back to /app
- update invite acceptance flows to default redirects to /app instead of the members area

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d53d6c607c8332aa6b5abecb62a306