### PR TITLE
Add admin membership RPCs and wire UI to new services

### DIFF
--- a/netlify/functions/deleteMember.ts
+++ b/netlify/functions/deleteMember.ts
@@ -46,9 +46,9 @@ export const handler: Handler = async (event) => {
     return json(500, { error: e?.message ?? 'Init error' });
   }
 
-  const { error } = await supabase.rpc('delete_member', {
-    p_org,
-    p_target,
+  const { error } = await supabase.rpc('admin_delete_member', {
+    p_org_id: p_org,
+    p_member_id: p_target,
   });
 
   if (error) {

--- a/netlify/functions/updateMemberRole.ts
+++ b/netlify/functions/updateMemberRole.ts
@@ -49,9 +49,9 @@ export const handler: Handler = async (event) => {
     return json(500, { error: e?.message ?? 'Init error' });
   }
 
-  const { error } = await supabase.rpc('update_member_role', {
-    p_org,
-    p_target,
+  const { error } = await supabase.rpc('admin_update_member_role', {
+    p_org_id: p_org,
+    p_member_id: p_target,
     p_role,
   });
 

--- a/scripts/test-perms.mjs
+++ b/scripts/test-perms.mjs
@@ -149,12 +149,12 @@ results.push(await runTest('team can read org members', async () => {
 // ADMIN update test
 results.push(await runTest('admin can update team role', async () => {
   const client = await getUserClient('ADMIN')
-  const { error } = await client.rpc('update_member_role', {
-    p_org: ORG_ID,
-    p_target: USERS.TEAM.id,
+  const { error } = await client.rpc('admin_update_member_role', {
+    p_org_id: ORG_ID,
+    p_member_id: USERS.TEAM.id,
     p_role: 'TEAM',
   })
-  if (error) throw new Error(`update_member_role failed: ${error.message}`)
+  if (error) throw new Error(`admin_update_member_role failed: ${error.message}`)
 
   const membership = await findMembership(USERS.TEAM.id)
   if (!membership) throw new Error('TEAM membership missing after update')
@@ -165,13 +165,13 @@ results.push(await runTest('admin can update team role', async () => {
 // CUSTOMER delete test
 results.push(await runTest('customer cannot delete members', async () => {
   const client = await getUserClient('CUSTOMER')
-  const resp = await client.rpc('delete_member', {
-    p_org: ORG_ID,
-    p_target: USERS.TEAM.id,
+  const resp = await client.rpc('admin_delete_member', {
+    p_org_id: ORG_ID,
+    p_member_id: USERS.TEAM.id,
   })
   if (!resp.error) {
     await ensureBaselineData()
-    throw new Error('delete_member succeeded for customer')
+    throw new Error('admin_delete_member succeeded for customer')
   }
   return `Denied with: ${resp.error.message}`
 }))
@@ -179,11 +179,11 @@ results.push(await runTest('customer cannot delete members', async () => {
 // ADMIN delete test
 results.push(await runTest('admin can delete members', async () => {
   const client = await getUserClient('ADMIN')
-  const { error } = await client.rpc('delete_member', {
-    p_org: ORG_ID,
-    p_target: USERS.TEAM.id,
+  const { error } = await client.rpc('admin_delete_member', {
+    p_org_id: ORG_ID,
+    p_member_id: USERS.TEAM.id,
   })
-  if (error) throw new Error(`delete_member failed: ${error.message}`)
+  if (error) throw new Error(`admin_delete_member failed: ${error.message}`)
 
   const membership = await findMembership(USERS.TEAM.id)
   if (membership) throw new Error('TEAM membership still exists after delete')

--- a/scripts/verify-admin-actions.mjs
+++ b/scripts/verify-admin-actions.mjs
@@ -128,25 +128,25 @@ let success = true;
 // Step A: admin updates team member role
 try {
   const adminClient = await createSessionClient(USERS.admin);
-  const { error } = await adminClient.rpc('update_member_role', {
-    p_org: ORG_ID,
-    p_target: USERS.team,
+  const { error } = await adminClient.rpc('admin_update_member_role', {
+    p_org_id: ORG_ID,
+    p_member_id: USERS.team,
     p_role: 'TEAM',
   });
   if (error) throw error;
   await assertMembershipRole(USERS.team, 'TEAM');
-  logPass('ADMIN update_member_role');
+  logPass('ADMIN admin_update_member_role');
 } catch (error) {
   success = false;
-  logFail('ADMIN update_member_role', error);
+  logFail('ADMIN admin_update_member_role', error);
 }
 
 // Step B: customer forbidden to update
 try {
   const customerClient = await createSessionClient(USERS.customer);
-  const { error } = await customerClient.rpc('update_member_role', {
-    p_org: ORG_ID,
-    p_target: USERS.team,
+  const { error } = await customerClient.rpc('admin_update_member_role', {
+    p_org_id: ORG_ID,
+    p_member_id: USERS.team,
     p_role: 'TEAM',
   });
   if (!error) {
@@ -156,18 +156,18 @@ try {
   if (status !== 403 && error.code !== '42501') {
     throw Object.assign(new Error('Unexpected error response'), formatFailure(error));
   }
-  logPass('CUSTOMER update_member_role blocked', `${error.code ?? error.status}: ${error.message}`);
+  logPass('CUSTOMER admin_update_member_role blocked', `${error.code ?? error.status}: ${error.message}`);
 } catch (error) {
   success = false;
-  logFail('CUSTOMER update_member_role blocked', error);
+  logFail('CUSTOMER admin_update_member_role blocked', error);
 }
 
 // Step C: admin deletes customer member
 try {
   const adminClient = await createSessionClient(USERS.admin);
-  const { error } = await adminClient.rpc('delete_member', {
-    p_org: ORG_ID,
-    p_target: USERS.customer,
+  const { error } = await adminClient.rpc('admin_delete_member', {
+    p_org_id: ORG_ID,
+    p_member_id: USERS.customer,
   });
   if (error) throw error;
   const { data, error: lookupError } = await serviceClient
@@ -183,7 +183,7 @@ try {
     throw Object.assign(new Error('Customer membership still present after delete'), { code: 'NOTDELETED' });
   }
   await restoreMembership(USERS.customer, 'CUSTOMER');
-  logPass('ADMIN delete_member', 'Membership removed and restored');
+  logPass('ADMIN admin_delete_member', 'Membership removed and restored');
 } catch (error) {
   success = false;
   try {
@@ -191,7 +191,7 @@ try {
   } catch (restoreError) {
     logFail('RESTORE membership fallback', restoreError);
   }
-  logFail('ADMIN delete_member', error);
+  logFail('ADMIN admin_delete_member', error);
 }
 
 if (!success) process.exit(1);

--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -1,0 +1,16 @@
+// Structured logging helpers
+function asObject(data) {
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    return data;
+  }
+  if (data === undefined) return {};
+  return { value: data };
+}
+
+export function warn(event, data = {}) {
+  console.warn(event, asObject(data));
+}
+
+export function error(event, data = {}) {
+  console.error(event, asObject(data));
+}

--- a/src/services/members.js
+++ b/src/services/members.js
@@ -1,0 +1,60 @@
+import { supabase } from '../lib/supabaseClient';
+import { error as logError } from '../lib/log';
+
+const MEMBER_ROLES = ['ADMIN', 'TEAM', 'CUSTOMER'];
+
+function normalizeRole(role) {
+  if (!role) return '';
+  return String(role).trim().toUpperCase();
+}
+
+function loggableError(err) {
+  if (!err) return null;
+  const base = typeof err === 'object' ? err : { message: String(err) };
+  return {
+    message: base.message ?? String(base),
+    code: base.code ?? base.status ?? null,
+    details: base.details ?? undefined,
+  };
+}
+
+export async function deleteMember(orgId, memberUserId) {
+  const { data, error } = await supabase.rpc('admin_delete_member', {
+    p_org_id: orgId,
+    p_member_id: memberUserId,
+  });
+
+  if (error) {
+    logError('services.members.delete_member_failed', {
+      orgId,
+      memberUserId,
+      error: loggableError(error),
+    });
+    throw error;
+  }
+
+  return data;
+}
+
+export async function updateMemberRole(orgId, memberUserId, role) {
+  const nextRole = normalizeRole(role);
+  const { data, error } = await supabase.rpc('admin_update_member_role', {
+    p_org_id: orgId,
+    p_member_id: memberUserId,
+    p_role: nextRole,
+  });
+
+  if (error) {
+    logError('services.members.update_member_role_failed', {
+      orgId,
+      memberUserId,
+      role: nextRole,
+      error: loggableError(error),
+    });
+    throw error;
+  }
+
+  return data;
+}
+
+export { MEMBER_ROLES };

--- a/supabase/migrations/20251001-01_admin-members-rpcs.sql
+++ b/supabase/migrations/20251001-01_admin-members-rpcs.sql
@@ -1,0 +1,106 @@
+-- Create admin RPCs for managing memberships with audit logging
+create or replace function public.admin_delete_member(
+  p_org_id uuid,
+  p_member_id uuid
+) returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_can_delete boolean;
+  v_actor uuid := auth.uid();
+begin
+  if v_actor is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  select public.has_permission(p_org_id, 'members.delete')
+    into v_can_delete;
+
+  if not coalesce(v_can_delete, false) then
+    raise exception 'forbidden: missing permission members.delete'
+      using errcode = '42501';
+  end if;
+
+  if p_member_id = v_actor then
+    raise exception 'bad_request: cannot delete yourself via admin_delete_member'
+      using errcode = '22023';
+  end if;
+
+  delete from public.memberships as m
+  where m.org_id = p_org_id
+    and m.user_id = p_member_id;
+
+  if not found then
+    raise exception 'membership not found' using errcode = 'P0002';
+  end if;
+
+  perform public.audit_log_event(
+    action => 'member_deleted',
+    org_id => p_org_id,
+    entity => 'memberships',
+    entity_id => p_member_id::text,
+    meta => jsonb_build_object('by', v_actor::text)
+  );
+end;
+$$;
+
+create or replace function public.admin_update_member_role(
+  p_org_id uuid,
+  p_member_id uuid,
+  p_role text
+) returns void
+language plpgsql
+security invoker
+set search_path = public
+as $$
+declare
+  v_can_update boolean;
+  v_actor uuid := auth.uid();
+  v_role text := upper(coalesce(p_role, ''));
+begin
+  if v_actor is null then
+    raise exception 'not_authenticated' using errcode = '28000';
+  end if;
+
+  if v_role not in ('ADMIN', 'TEAM', 'CUSTOMER') then
+    raise exception 'bad_request: invalid role %', v_role using errcode = '22023';
+  end if;
+
+  select public.has_permission(p_org_id, 'members.update')
+    into v_can_update;
+
+  if not coalesce(v_can_update, false) then
+    raise exception 'forbidden: missing permission members.update'
+      using errcode = '42501';
+  end if;
+
+  if p_member_id = v_actor and v_role <> 'ADMIN' then
+    raise exception 'bad_request: cannot downgrade your own role'
+      using errcode = '22023';
+  end if;
+
+  update public.memberships as m
+     set role = v_role::role_type
+   where m.org_id = p_org_id
+     and m.user_id = p_member_id;
+
+  if not found then
+    raise exception 'membership not found' using errcode = 'P0002';
+  end if;
+
+  perform public.audit_log_event(
+    action => 'member_role_updated',
+    org_id => p_org_id,
+    entity => 'memberships',
+    entity_id => p_member_id::text,
+    meta => jsonb_build_object('by', v_actor::text, 'new_role', v_role)
+  );
+end;
+$$;
+
+grant execute on function public.admin_delete_member(uuid, uuid) to authenticated;
+grant execute on function public.admin_update_member_role(uuid, uuid, text) to authenticated;
+
+notify pgrst, 'reload schema';

--- a/supabase/migrations/20251001-02_memberships-rls-policies.sql
+++ b/supabase/migrations/20251001-02_memberships-rls-policies.sql
@@ -1,0 +1,27 @@
+-- Refresh RLS policies for memberships to require explicit permissions
+alter table public.memberships enable row level security;
+
+drop policy if exists memberships_delete_by_admin on public.memberships;
+drop policy if exists admin_delete_membership on public.memberships;
+create policy memberships_delete_by_admin
+on public.memberships
+for delete
+to authenticated
+using (
+  public.has_permission(org_id, 'members.delete')
+);
+
+drop policy if exists memberships_update_role_by_admin on public.memberships;
+drop policy if exists admin_update_member_role on public.memberships;
+create policy memberships_update_role_by_admin
+on public.memberships
+for update
+to authenticated
+using (
+  public.has_permission(org_id, 'members.update')
+)
+with check (
+  public.has_permission(org_id, 'members.update')
+);
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add admin_delete_member and admin_update_member_role RPCs with audit logging and permission checks
- refresh memberships RLS policies and update Netlify handlers, scripts, and client services to use the new RPCs
- refactor MembersAdmin UI to use Supabase RPC services with structured logging and refetching after mutations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd8021e660833286ac69fd8676c85c