### PR TITLE
Restrict members navigation link to admins

### DIFF
--- a/src/components/BluelineChatpilot.jsx
+++ b/src/components/BluelineChatpilot.jsx
@@ -1,4 +1,4 @@
-// change: removed PermissionGate wrapper around Members nav item
+// change: Members link visible only for authenticated ADMIN; removed blocking wrappers
 import React, { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
@@ -205,33 +205,7 @@ function AppSidebar({ open, onToggleSidebar, onToggleFeed, feedOpen, onNewChat, 
   const expanded = !!open;
   const sidebarWidth = expanded ? 256 : 56;
 
-  const { roleForActiveOrg, activeOrgId, hasPermission } = useAuth();
-  const isAdmin = roleForActiveOrg === 'ADMIN';
-  const [membersGateReady, setMembersGateReady] = React.useState(false);
-  const [canSeeMembers, setCanSeeMembers] = React.useState(false);
-
-  React.useEffect(() => {
-    let cancelled = false;
-
-    if (!isAdmin || !activeOrgId) {
-      setCanSeeMembers(false);
-      setMembersGateReady(true);
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    setMembersGateReady(false);
-    hasPermission(activeOrgId, 'members.read').then((result) => {
-      if (cancelled) return;
-      setCanSeeMembers(Boolean(result));
-      setMembersGateReady(true);
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [activeOrgId, hasPermission, isAdmin]);
+  const { session, roleForActiveOrg } = useAuth();
 
   // Tooltip (fixed gepositioneerd: geen horizontale scrollbar)
   const [tip, setTip] = React.useState({ text: "", x: 0, y: 0, show: false });
@@ -314,26 +288,28 @@ function AppSidebar({ open, onToggleSidebar, onToggleFeed, feedOpen, onNewChat, 
           </div>
 
           {/* --- Ledenbeheer (alleen zichtbaar voor admins) --- */}
-          <NavLink
-            to="/app/members"
-            title="Ledenbeheer"
-            className={({ isActive }) => [
-              "group flex items-center gap-3 rounded-xl px-3 py-2 transition-colors",
-              expanded ? "justify-start" : "justify-center",
-              isActive
-                ? "bg-[#e8efff] text-[#194297]"
-                : "text-[#66676b] hover:bg-[#f3f6ff] hover:text-[#194297]",
-            ].join(' ')}
-          >
-            {/* people/users icon */}
-            <svg width="20" height="20" viewBox="0 0 24 24" className="shrink-0">
-              <path
-                fill="currentColor"
-                d="M16 13a4 4 0 1 0-4-4a4 4 0 0 0 4 4m-8 0a3 3 0 1 0-3-3a3 3 0 0 0 3 3m8 2c-2.67 0-8 1.34-8 4v 2h16v-2c0-2.66-5.33-4-8-4m-8-1c-3 0-9 1.5-9 4v2h6v-2c0-1.35.74-2.5 1.93-3.41A11.5 11.5 0 0 0 0 18h0"
-              />
-            </svg>
-            {expanded && <span className="text-[14px] font-medium">Ledenbeheer</span>}
-          </NavLink>
+          {session && roleForActiveOrg === 'ADMIN' && (
+            <NavLink
+              to="/app/members"
+              title="Ledenbeheer"
+              className={({ isActive }) => [
+                "group flex items-center gap-3 rounded-xl px-3 py-2 transition-colors",
+                expanded ? "justify-start" : "justify-center",
+                isActive
+                  ? "bg-[#e8efff] text-[#194297]"
+                  : "text-[#66676b] hover:bg-[#f3f6ff] hover:text-[#194297]",
+              ].join(' ')}
+            >
+              {/* people/users icon */}
+              <svg width="20" height="20" viewBox="0 0 24 24" className="shrink-0">
+                <path
+                  fill="currentColor"
+                  d="M16 13a4 4 0 1 0-4-4a4 4 0 0 0 4 4m-8 0a3 3 0 1 0-3-3a3 3 0 0 0 3 3m8 2c-2.67 0-8 1.34-8 4v 2h16v-2c0-2.66-5.33-4-8-4m-8-1c-3 0-9 1.5-9 4v2h6v-2c0-1.35.74-2.5 1.93-3.41A11.5 11.5 0 0 0 0 18h0"
+                />
+              </svg>
+              {expanded && <span className="text-[14px] font-medium">Ledenbeheer</span>}
+            </NavLink>
+          )}
 
           {/* Newsfeed bij uitgeklapt */}
           {feedOpen && expanded && (


### PR DESCRIPTION
## Summary
- only render the Members navigation link when the authenticated user is an admin

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de84af59688332b6e97c544a61f405