### PR TITLE
Add Supabase knowledge base search service

### DIFF
--- a/src/services/kb.js
+++ b/src/services/kb.js
@@ -1,0 +1,18 @@
+export async function searchKb({ supabase, orgId, query, limit }) {
+  const { data, error } = await supabase.rpc('kb_search_chunks', {
+    p_org: orgId,
+    q: query,
+    k: limit ?? 3,
+  });
+
+  const items = Array.isArray(data)
+    ? data.map((row, index) => ({
+        id: row?.id ?? row?.chunk_id ?? row?.document_id ?? null,
+        title: row?.title ?? row?.chunk_title ?? row?.document_title ?? '',
+        snippet: row?.snippet ?? row?.chunk_snippet ?? row?.content ?? '',
+        rank: row?.rank ?? index + 1,
+      }))
+    : [];
+
+  return { items, error };
+}


### PR DESCRIPTION
## Summary
- add `searchKb` service that calls the `kb_search_chunks` Supabase RPC
- normalize the returned rows into `{ id, title, snippet, rank }` items and forward errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfe466d5948332a696299000787541