### PR TITLE
Add server-side Supabase fallback for Gemini function

### DIFF
--- a/netlify/functions/supabaseServer.js
+++ b/netlify/functions/supabaseServer.js
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseServer = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY,
+  { auth: { persistSession: false } }
+);
+
+export default supabaseServer;


### PR DESCRIPTION
## Summary
- add a reusable Supabase service-role client for Netlify functions
- update generate-gemini function to resolve knowledge base data server-side when the UI does not supply it
- enrich metadata and debugging output with the effective knowledge base titles and counts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e12f5d87a08332a77cdf72e17fc0be