### PR TITLE
Add numeric KB fact lock and display used knowledge tags

### DIFF
--- a/.codex/patches/011-fact-lock-postcheck.diff
+++ b/.codex/patches/011-fact-lock-postcheck.diff
@@ -1,0 +1,62 @@
+diff --git a/netlify/functions/generate-gemini.js b/netlify/functions/generate-gemini.js
+index 7c3a2b8..893e4ee 100644
+--- a/netlify/functions/generate-gemini.js
++++ b/netlify/functions/generate-gemini.js
+@@ -341,35 +341,34 @@ const promptPreview = userPrompt.slice(0, 600);
+       return new Response(JSON.stringify(payload), { status: 502, headers: JSON_HEADERS });
+     }
+ 
++    let modelText = stripSubjectLine(firstText);
++    let safeText = modelText; // mutable copy for post-processing
++
+     // ---- Numeric fact lock (post-check) ----
+-function extractFacts(text) {
+-  if (typeof text !== "string") return [];
+-  const facts = [];
+-  // zoek combinaties "24 maanden", "30 dagen", etc.
+-  const re = /\b(\d+)\s*(dagen?|maanden?)\b/gi;
+-  let m;
+-  while ((m = re.exec(text)) !== null) {
+-    facts.push({ n: m[1], unit: m[2].toLowerCase(), raw: m[0] });
+-  }
+-  return facts;
+-}
++    function extractFacts(text) {
++      if (typeof text !== "string") return [];
++      const facts = [];
++      const re = /\b(\d+)\s*(dagen?|maanden?)\b/gi; // e.g., "30 dagen", "24 maanden"
++      let m;
++      while ((m = re.exec(text)) !== null) {
++        facts.push({ n: m[1], unit: m[2].toLowerCase(), raw: m[0] });
++      }
++      return facts;
++    }
+ 
+-const kbText = (Array.isArray(kb) ? kb.map(x => x.snippet).join(" ") : "") || "";
+-const kbFacts = extractFacts(kbText);
+-const ansFacts = extractFacts(modelText);
++    const kbText = (Array.isArray(kb) ? kb.map((x) => x?.snippet || "").join(" ") : "") || "";
++    const kbFacts = extractFacts(kbText);
++    const ansFacts = extractFacts(safeText);
+ 
+-// Als KB feiten heeft, maar antwoord geen enkel exact KB-getal bevat → minimale correctie
+-if (kbFacts.length && !ansFacts.some(af => kbFacts.some(kf => af.n === kf.n && af.unit === kf.unit))) {
+-  // Kies het eerste KB-feit als “belangrijkste”
+-  const main = kbFacts[0];
+-  modelText = `${modelText} ${main.n} ${main.unit} volgens de kennisbank.`;
+-}
++    // Als KB feiten heeft maar geen enkel exact KB-getal in het antwoord staat → voeg 1 zin toe
++    if (kbFacts.length && !ansFacts.some((af) => kbFacts.some((kf) => af.n === kf.n && af.unit === kf.unit))) {
++      const main = kbFacts[0]; // pak het eerste KB-feit
++      safeText = `${safeText} ${main.n} ${main.unit} volgens de kennisbank.`;
++    }
+ 
+-let modelText = stripSubjectLine(firstText);
+     // Als het kanaal "social" is: maximaal 4 zinnen, max 1 emoji
+     const isSocial = typeof type === "string" && /social/i.test(type);
+-    const finalText = isSocial ? stripSocialToTwoSentences(modelText) : modelText;
+-
++    const finalText = isSocial ? stripSocialToTwoSentences(safeText) : safeText;
+     const respPayload = {
+       text: finalText,
+       meta: {

--- a/.codex/patches/012-ui-usedkb-tags.diff
+++ b/.codex/patches/012-ui-usedkb-tags.diff
@@ -1,0 +1,37 @@
+diff --git a/src/components/BluelineChatpilot.jsx b/src/components/BluelineChatpilot.jsx
+index ba7b099..c7b8847 100644
+--- a/src/components/BluelineChatpilot.jsx
++++ b/src/components/BluelineChatpilot.jsx
+@@ -758,7 +758,6 @@ function BluelineChatpilotInner() {
+                   <div className="py-5 flex flex-col gap-5" ref={listRef} role="log" aria-live="polite">
+                     {messages.filter(m=>m.text !== "__hero__").map((m, idx) => {
+                       const isUser = m.role === "user";
+-                      const usedKbItems = !isUser && Array.isArray(m?.meta?.usedKb) ? m.meta.usedKb : [];
+                       return (
+                         <div key={idx} className={cx("flex", isUser ? "justify-end" : "justify-start")}>
+                           <div className={cx("flex flex-col gap-2 max-w-[560px]", isUser ? "items-end" : "items-start")}>
+@@ -772,9 +771,21 @@ function BluelineChatpilotInner() {
+                             >
+                               {m.text}
+                             </div>
+-                            {!isUser && usedKbItems.length > 0 && (
+-                              <div className="max-w-[560px] text-sm text-gray-500 mt-2">
+-                                🛈 Gebruikte kennisbank: {usedKbItems.map((item) => item?.title || "Onbekende bron").join(", ")}
++                            {!isUser && Array.isArray(m.meta?.usedKb) && m.meta.usedKb.length > 0 && (
++                              <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-gray-600">
++                                <span className="inline-flex items-center gap-1">
++                                  <span>🛈</span>
++                                  <span>Gebruikte kennisbank:</span>
++                                </span>
++                                {m.meta.usedKb.map((t, i) => (
++                                  <span
++                                    key={i}
++                                    className="px-2 py-0.5 rounded-full bg-gray-100 text-gray-700 border border-gray-200"
++                                    title={t || 'Onbekende bron'}
++                                  >
++                                    {t || 'Onbekende bron'}
++                                  </span>
++                                ))}
+                               </div>
+                             )}
+                           </div>

--- a/netlify/functions/generate-gemini.js
+++ b/netlify/functions/generate-gemini.js
@@ -341,35 +341,34 @@ const promptPreview = userPrompt.slice(0, 600);
       return new Response(JSON.stringify(payload), { status: 502, headers: JSON_HEADERS });
     }
 
+    let modelText = stripSubjectLine(firstText);
+    let safeText = modelText; // mutable copy for post-processing
+
     // ---- Numeric fact lock (post-check) ----
-function extractFacts(text) {
-  if (typeof text !== "string") return [];
-  const facts = [];
-  // zoek combinaties "24 maanden", "30 dagen", etc.
-  const re = /\b(\d+)\s*(dagen?|maanden?)\b/gi;
-  let m;
-  while ((m = re.exec(text)) !== null) {
-    facts.push({ n: m[1], unit: m[2].toLowerCase(), raw: m[0] });
-  }
-  return facts;
-}
+    function extractFacts(text) {
+      if (typeof text !== "string") return [];
+      const facts = [];
+      const re = /\b(\d+)\s*(dagen?|maanden?)\b/gi; // e.g., "30 dagen", "24 maanden"
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        facts.push({ n: m[1], unit: m[2].toLowerCase(), raw: m[0] });
+      }
+      return facts;
+    }
 
-const kbText = (Array.isArray(kb) ? kb.map(x => x.snippet).join(" ") : "") || "";
-const kbFacts = extractFacts(kbText);
-const ansFacts = extractFacts(modelText);
+    const kbText = (Array.isArray(kb) ? kb.map((x) => x?.snippet || "").join(" ") : "") || "";
+    const kbFacts = extractFacts(kbText);
+    const ansFacts = extractFacts(safeText);
 
-// Als KB feiten heeft, maar antwoord geen enkel exact KB-getal bevat → minimale correctie
-if (kbFacts.length && !ansFacts.some(af => kbFacts.some(kf => af.n === kf.n && af.unit === kf.unit))) {
-  // Kies het eerste KB-feit als “belangrijkste”
-  const main = kbFacts[0];
-  modelText = `${modelText} ${main.n} ${main.unit} volgens de kennisbank.`;
-}
+    // Als KB feiten heeft maar geen enkel exact KB-getal in het antwoord staat → voeg 1 zin toe
+    if (kbFacts.length && !ansFacts.some((af) => kbFacts.some((kf) => af.n === kf.n && af.unit === kf.unit))) {
+      const main = kbFacts[0]; // pak het eerste KB-feit
+      safeText = `${safeText} ${main.n} ${main.unit} volgens de kennisbank.`;
+    }
 
-let modelText = stripSubjectLine(firstText);
     // Als het kanaal "social" is: maximaal 4 zinnen, max 1 emoji
     const isSocial = typeof type === "string" && /social/i.test(type);
-    const finalText = isSocial ? stripSocialToTwoSentences(modelText) : modelText;
-
+    const finalText = isSocial ? stripSocialToTwoSentences(safeText) : safeText;
     const respPayload = {
       text: finalText,
       meta: {

--- a/src/components/BluelineChatpilot.jsx
+++ b/src/components/BluelineChatpilot.jsx
@@ -758,7 +758,6 @@ function BluelineChatpilotInner() {
                   <div className="py-5 flex flex-col gap-5" ref={listRef} role="log" aria-live="polite">
                     {messages.filter(m=>m.text !== "__hero__").map((m, idx) => {
                       const isUser = m.role === "user";
-                      const usedKbItems = !isUser && Array.isArray(m?.meta?.usedKb) ? m.meta.usedKb : [];
                       return (
                         <div key={idx} className={cx("flex", isUser ? "justify-end" : "justify-start")}>
                           <div className={cx("flex flex-col gap-2 max-w-[560px]", isUser ? "items-end" : "items-start")}>
@@ -772,9 +771,21 @@ function BluelineChatpilotInner() {
                             >
                               {m.text}
                             </div>
-                            {!isUser && usedKbItems.length > 0 && (
-                              <div className="max-w-[560px] text-sm text-gray-500 mt-2">
-                                🛈 Gebruikte kennisbank: {usedKbItems.map((item) => item?.title || "Onbekende bron").join(", ")}
+                            {!isUser && Array.isArray(m.meta?.usedKb) && m.meta.usedKb.length > 0 && (
+                              <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-gray-600">
+                                <span className="inline-flex items-center gap-1">
+                                  <span>🛈</span>
+                                  <span>Gebruikte kennisbank:</span>
+                                </span>
+                                {m.meta.usedKb.map((t, i) => (
+                                  <span
+                                    key={i}
+                                    className="px-2 py-0.5 rounded-full bg-gray-100 text-gray-700 border border-gray-200"
+                                    title={t || 'Onbekende bron'}
+                                  >
+                                    {t || 'Onbekende bron'}
+                                  </span>
+                                ))}
                               </div>
                             )}
                           </div>


### PR DESCRIPTION
## Summary
- make the Gemini response text mutable so numeric KB facts can be enforced before returning
- ensure the social limiter and response payload use the post-checked text
- render knowledge base source tags under assistant replies in the chat UI when meta.usedKb is present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e17935cefc8332b369d1d79acbaeb7